### PR TITLE
MP handthrottle sync and rangesplitter binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Download FS25_realismAddon_gearbox.zip from the releases section and put it into
 ###### V 0.9.0.6
 
 - added binding for secondGroup gears 2 or 1, to support range splitter switches on SKRS style shiftknobs
+- fix MP sync issue, where handthrottle is set to around 50% when entering vehicles and coupling or decoupling attachments
 
 ###### V 0.9.0.5
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ So for now the features are final I think - at least for a first final version. 
 
 Download FS25_realismAddon_gearbox.zip from the releases section and put it into your mods folder.
 
-
 # Feature List FS25
 
 - removes all unnatural/automatic braking, only adding back Engine Braking depending on gearRatio
@@ -32,15 +31,19 @@ Download FS25_realismAddon_gearbox.zip from the releases section and put it into
 - remove automatic full brake when clutching in reverse bug
 - added support for axis shifting for FPS transmissions
 - added handbrake
-- added support for second Group-Set so the usual Gears, Groups and second Group can be simulated. (for example Gears, R, L, H Group and L / H Powershift) Inputs need to be configured, nothing set by default
+- added support for second Group-Set so the usual Gears, Groups and second Group can be simulated. (for example Gears, R, L, H Group and L / H Powershift) Inputs need to be configured, nothing set by default, optionally a rangesplitter binding can be set, where the button press switches to H and release to L again
 - added optional Inputs for group5 to group8 since Giants default only allows 1-4
-
 
 # Changelog in FS25
 
+###### V 0.9.0.6
+
+- added binding for secondGroup gears 2 or 1, to support range splitter switches on SKRS style shiftknobs
+
 ###### V 0.9.0.5
+
 - fixed automatic transmissions not working
-- added automatic clutch opening when stopped on automatic transmissions so they can be used without clutch still 
+- added automatic clutch opening when stopped on automatic transmissions so they can be used without clutch still
 - added optional Inputs for group5 to group8 since Giants default only allows 1-4
 
 ###### V 0.9.0.4
@@ -69,14 +72,12 @@ Download FS25_realismAddon_gearbox.zip from the releases section and put it into
 
 - Initial Github Release: For a full Feature list look at the Feature List above
 
-
 # Changes between FS22 and FS25 conversion
 
 - added parkbrake/handbrake function. Since at the time of converting there were no other mods with this feature it was neccessary to add it.
   As EnhancedVehicle is now released the EV parking brake should work again and the REA-GB parking brake disable itself. If you don't use EV you have to set the Key Binds for the REA GB Parking Brake
 - added XML Support to change basegame Vehicle Gearbox Settings (currently inclueded are John Deere 3650, Zetor Proxima 120HD, Zetor Forterra HSX140 and Zetor Crystal, more will be added later)
 - fixed MP synchronization where Gears shifted with a Gear Lever were only synchronized up to Gear 7 making all Vehicles with H/L Gears in one impossible to play
-
 
 # Changelog in FS22
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,51 +1,88 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="101">
-    <author>modelleicher</author>
-    <version>0.9.0.5</version>
-    <title>
-        <de>RealismAddon: Gearbox</de>
+	<author>modelleicher</author>
+	<version>0.9.0.6</version>
+	<title>
+		<de>RealismAddon: Gearbox</de>
 		<en>RealismAddon: Gearbox</en>
-    </title>
-    <description>
-        <de>
+	</title>
+	<description>
+		<de>
 <![CDATA[RealismAddon: Gearbox]]>
         </de>
-	<en>
+		<en>
 <![CDATA[RealismAddon: Gearbox]]>
 	</en>
-    </description>
+	</description>
 
 	<iconFilename>store.dds</iconFilename>
 
-	
-    <multiplayer supported="true"/>
-    <extraSourceFiles>
-	
-        <sourceFile filename="realismAddon_gearbox_overrides.lua"/>
-		
-        <sourceFile filename="realismAddon_gearbox_register.lua"/>
-		
-    </extraSourceFiles>
-	
+
+	<multiplayer supported="true" />
+	<extraSourceFiles>
+
+		<sourceFile filename="realismAddon_gearbox_overrides.lua" />
+
+		<sourceFile filename="realismAddon_gearbox_register.lua" />
+
+	</extraSourceFiles>
+
 	<l10n>
-		<text name="input_RAGB_HANDTHROTTLE_UP"><de>Handgas erhöhen</de><en>hand throttle up</en></text>
-		<text name="input_RAGB_HANDTHROTTLE_DOWN"><de>Handgas verringern</de><en>hand throttle down</en></text>
-		<text name="input_RAGB_HANDTHROTTLE_AXIS"><de>Handgas Analoge Achse</de><en>hand throttle axis</en></text>
-		
-		<text name="input_RAGB_GEARSHIFT_AXIS"><de>Analoge Schaltachse (FPS Getriebe)</de><en>analog shift axis (FPS transmissions)</en></text>
-		
-		<text name="input_RAGB_GROUPSECOND_UP"><de>Zweites Gruppenset hochschalten</de><en>Group Second Set Up</en></text>
-		<text name="input_RAGB_GROUPSECOND_DOWN"><de>Zweites Gruppenset runterschalten</de><en>Group Second Set Down</en></text>
-		
-		<text name="input_RAGB_HANDBRAKE"><de>Handbremse ein/ausschalten</de><en>Handbrake on/off</en></text>
-		
-		<text name="input_RAGB_SHIFT_GROUP_5"><de>5. Gruppe schalten</de><en>Gear group 5</en></text>
-		<text name="input_RAGB_SHIFT_GROUP_6"><de>6. Gruppe schalten</de><en>Gear group 6</en></text>
-		<text name="input_RAGB_SHIFT_GROUP_7"><de>7. Gruppe schalten</de><en>Gear group 7</en></text>
-		<text name="input_RAGB_SHIFT_GROUP_8"><de>8. Gruppe schalten</de><en>Gear group 8</en></text>
+		<text name="input_RAGB_HANDTHROTTLE_UP">
+			<de>Handgas erhöhen</de>
+			<en>hand throttle up</en>
+		</text>
+		<text name="input_RAGB_HANDTHROTTLE_DOWN">
+			<de>Handgas verringern</de>
+			<en>hand throttle down</en>
+		</text>
+		<text name="input_RAGB_HANDTHROTTLE_AXIS">
+			<de>Handgas Analoge Achse</de>
+			<en>hand throttle axis</en>
+		</text>
+
+		<text name="input_RAGB_GEARSHIFT_AXIS">
+			<de>Analoge Schaltachse (FPS Getriebe)</de>
+			<en>analog shift axis (FPS transmissions)</en>
+		</text>
+
+		<text name="input_RAGB_GROUPSECOND_UP">
+			<de>Zweites Gruppenset hochschalten</de>
+			<en>Group Second Set Up</en>
+		</text>
+		<text name="input_RAGB_GROUPSECOND_DOWN">
+			<de>Zweites Gruppenset runterschalten</de>
+			<en>Group Second Set Down</en>
+		</text>
+		<text name="input_RAGB_GROUPSECOND_TWO_OR_ONE">
+			<de>Zweites Gruppenset 2 oder 1 (z.B. H/L für Rangesplitter)</de>
+			<en>Group Second Set 2 or 1 (e.g. H/L for range splitter)</en>
+		</text>
+
+		<text name="input_RAGB_HANDBRAKE">
+			<de>Handbremse ein/ausschalten</de>
+			<en>Handbrake on/off</en>
+		</text>
+
+		<text name="input_RAGB_SHIFT_GROUP_5">
+			<de>5. Gruppe schalten</de>
+			<en>Gear group 5</en>
+		</text>
+		<text name="input_RAGB_SHIFT_GROUP_6">
+			<de>6. Gruppe schalten</de>
+			<en>Gear group 6</en>
+		</text>
+		<text name="input_RAGB_SHIFT_GROUP_7">
+			<de>7. Gruppe schalten</de>
+			<en>Gear group 7</en>
+		</text>
+		<text name="input_RAGB_SHIFT_GROUP_8">
+			<de>8. Gruppe schalten</de>
+			<en>Gear group 8</en>
+		</text>
 
 	</l10n>
-	
+
 	<inputBinding>
 		<actionBinding action="RAGB_HANDTHROTTLE_UP">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
@@ -55,53 +92,57 @@
 		</actionBinding>
 		<actionBinding action="RAGB_HANDTHROTTLE_AXIS">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
-		</actionBinding>	
-		
+		</actionBinding>
+
 		<actionBinding action="RAGB_GEARSHIFT_AXIS">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
 		</actionBinding>
 
 		<actionBinding action="RAGB_GROUPSECOND_UP">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
-		</actionBinding>	
+		</actionBinding>
 		<actionBinding action="RAGB_GROUPSECOND_DOWN">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
-		</actionBinding>		
+		</actionBinding>
+		<actionBinding action="RAGB_GROUPSECOND_TWO_OR_ONE">
+			<binding device="KB_MOUSE_DEFAULT" input="" />
+		</actionBinding>
 
 		<actionBinding action="RAGB_HANDBRAKE">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
-		</actionBinding>	
+		</actionBinding>
 
 		<actionBinding action="RAGB_SHIFT_GROUP_5">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
-		</actionBinding>	
+		</actionBinding>
 		<actionBinding action="RAGB_SHIFT_GROUP_6">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
-		</actionBinding>	
+		</actionBinding>
 		<actionBinding action="RAGB_SHIFT_GROUP_7">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
 		</actionBinding>
 		<actionBinding action="RAGB_SHIFT_GROUP_8">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
-		</actionBinding>		
+		</actionBinding>
 	</inputBinding>
-	
+
 	<actions>
 		<action name="RAGB_HANDTHROTTLE_AXIS" />
 		<action name="RAGB_HANDTHROTTLE_DOWN" />
 		<action name="RAGB_HANDTHROTTLE_UP" />
-		
+
 		<action name="RAGB_GEARSHIFT_AXIS" />
-		
+
 		<action name="RAGB_GROUPSECOND_UP" />
 		<action name="RAGB_GROUPSECOND_DOWN" />
+		<action name="RAGB_GROUPSECOND_TWO_OR_ONE" />
 
-		<action name="RAGB_HANDBRAKE" />	
-		
-		<action name="RAGB_SHIFT_GROUP_5" />		
-		<action name="RAGB_SHIFT_GROUP_6" />		
-		<action name="RAGB_SHIFT_GROUP_7" />		
-		<action name="RAGB_SHIFT_GROUP_8" />		
-	</actions>	
-	
+		<action name="RAGB_HANDBRAKE" />
+
+		<action name="RAGB_SHIFT_GROUP_5" />
+		<action name="RAGB_SHIFT_GROUP_6" />
+		<action name="RAGB_SHIFT_GROUP_7" />
+		<action name="RAGB_SHIFT_GROUP_8" />
+	</actions>
+
 </modDesc>

--- a/realismAddon_gearbox_inputs.lua
+++ b/realismAddon_gearbox_inputs.lua
@@ -193,6 +193,10 @@ function realismAddon_gearbox_inputs.registerEventListeners(vehicleType)
 	SpecializationUtil.registerEventListener(vehicleType, "onReadUpdateStream", realismAddon_gearbox_inputs)
 
 	SpecializationUtil.registerEventListener(vehicleType, "onRegisterActionEvents", realismAddon_gearbox_inputs)
+
+	-- Listen for attach/detach to force sync
+	SpecializationUtil.registerEventListener(vehicleType, "onPostAttach", realismAddon_gearbox_inputs)
+	SpecializationUtil.registerEventListener(vehicleType, "onPreDetach", realismAddon_gearbox_inputs)
 end
 
 function realismAddon_gearbox_inputs.registerFunctions(vehicleType) end
@@ -219,6 +223,9 @@ function realismAddon_gearbox_inputs:onLoad(savegame)
 	spec.handThrottleUp = false
 
 	spec.synchHandThrottleDirtyFlag = self:getNextDirtyFlag()
+
+	-- Force sync after load
+	self:raiseDirtyFlags(spec.synchHandThrottleDirtyFlag)
 
 	-- gear shift axis values
 	spec.gearAxisPosition = 0
@@ -306,3 +313,17 @@ MotorGearShiftEvent.writeStream = Utils.overwrittenFunction(
 	MotorGearShiftEvent.writeStream,
 	realismAddon_gearbox_inputs.MotorGearShiftEvent_writeStream
 )
+
+function realismAddon_gearbox_inputs:onPostAttach(attacherVehicle, inputJointDescIndex, jointDescIndex)
+	local spec = self.spec_realismAddon_gearbox_inputs
+	if spec and spec.synchHandThrottleDirtyFlag then
+		self:raiseDirtyFlags(spec.synchHandThrottleDirtyFlag)
+	end
+end
+
+function realismAddon_gearbox_inputs:onPreDetach(attacherVehicle, implement)
+	local spec = self.spec_realismAddon_gearbox_inputs
+	if spec and spec.synchHandThrottleDirtyFlag then
+		self:raiseDirtyFlags(spec.synchHandThrottleDirtyFlag)
+	end
+end

--- a/realismAddon_gearbox_inputs.lua
+++ b/realismAddon_gearbox_inputs.lua
@@ -1,84 +1,101 @@
 -- by modelleicher ( Farming Agency )
--- Inputs for realismAddon_gearbox 
+-- Inputs for realismAddon_gearbox
 
 realismAddon_gearbox_inputs = {}
 
 function realismAddon_gearbox_inputs.prerequisitesPresent(specializations)
-    return true
+	return true
 end
 
--- Action Event Adding 
--- custom function for adding actionEvents since there might be a lot 
+-- Action Event Adding
+-- custom function for adding actionEvents since there might be a lot
 function realismAddon_gearbox_inputs.onRegisterActionEvents(self, isActiveForInput, isActiveForInputIgnoreSelection)
-	
-
 	if self.isClient then
 		local spec = self.spec_realismAddon_gearbox_inputs
-		
+
 		if (isActiveForInputIgnoreSelection or isActiveForInput) and spec.allManualActive then
-		
-			-- hand throttle 
+			-- hand throttle
 			self:addRealismAddonActionEvent("PRESSED_OR_AXIS", "RAGB_HANDTHROTTLE_UP", "HANDTHROTTLE_INPUT")
 			self:addRealismAddonActionEvent("PRESSED_OR_AXIS", "RAGB_HANDTHROTTLE_DOWN", "HANDTHROTTLE_INPUT")
 			self:addRealismAddonActionEvent("PRESSED_OR_AXIS", "RAGB_HANDTHROTTLE_AXIS", "HANDTHROTTLE_INPUT")
-			
-			-- gear shift via axis 
-			self:addRealismAddonActionEvent("PRESSED_OR_AXIS", "RAGB_GEARSHIFT_AXIS", "RAGB_GEARSHIFT_AXIS")	
+
+			-- gear shift via axis
+			self:addRealismAddonActionEvent("PRESSED_OR_AXIS", "RAGB_GEARSHIFT_AXIS", "RAGB_GEARSHIFT_AXIS")
 
 			-- second group set
-			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_GROUPSECOND_UP", "GROUPSECOND_INPUT")			
-			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_GROUPSECOND_DOWN", "GROUPSECOND_INPUT")	
-			
+			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_GROUPSECOND_UP", "GROUPSECOND_INPUT")
+			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_GROUPSECOND_DOWN", "GROUPSECOND_INPUT")
+			self:addRealismAddonActionEvent("BUTTON_DOUBLE_ACTION", "RAGB_GROUPSECOND_TWO_OR_ONE", "GROUPSECOND_INPUT")
+
 			-- handbrake
-			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_HANDBRAKE", "HANDBRAKE_INPUT")			
+			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_HANDBRAKE", "HANDBRAKE_INPUT")
 
 			-- group 5 - 8 individual shifting since Giants only allows 1-4
-			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_SHIFT_GROUP_5", "GROUP58_MANUAL_INPUT")	
-			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_SHIFT_GROUP_6", "GROUP58_MANUAL_INPUT")	
-			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_SHIFT_GROUP_7", "GROUP58_MANUAL_INPUT")	
-			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_SHIFT_GROUP_8", "GROUP58_MANUAL_INPUT")	
-		
+			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_SHIFT_GROUP_5", "GROUP58_MANUAL_INPUT")
+			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_SHIFT_GROUP_6", "GROUP58_MANUAL_INPUT")
+			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_SHIFT_GROUP_7", "GROUP58_MANUAL_INPUT")
+			self:addRealismAddonActionEvent("BUTTON_SINGLE_ACTION", "RAGB_SHIFT_GROUP_8", "GROUP58_MANUAL_INPUT")
 		end
-
 	end
 end
 
 function realismAddon_gearbox_inputs:addRealismAddonActionEvent(type, inputAction, func, showHud)
 	local spec = self.spec_realismAddon_gearbox_inputs
-	
-	spec.actionEvents = {}
-	self:clearActionEventsTable(spec.actionEvents) 
-	
 
+	spec.actionEvents = {}
+	self:clearActionEventsTable(spec.actionEvents)
 
 	local _, actionEventId = nil
 	if type == "BUTTON_SINGLE_ACTION" then
-		_ , actionEventId = self:addActionEvent(spec.actionEvents, InputAction[inputAction], self, realismAddon_gearbox_inputs[func], false, true, false, true)
+		_, actionEventId = self:addActionEvent(
+			spec.actionEvents,
+			InputAction[inputAction],
+			self,
+			realismAddon_gearbox_inputs[func],
+			false,
+			true,
+			false,
+			true
+		)
 	elseif type == "BUTTON_DOUBLE_ACTION" then
-		_ , actionEventId = self:addActionEvent(spec.actionEvents, InputAction[inputAction], self, realismAddon_gearbox_inputs[func], true, true, false, true)	
+		_, actionEventId = self:addActionEvent(
+			spec.actionEvents,
+			InputAction[inputAction],
+			self,
+			realismAddon_gearbox_inputs[func],
+			true,
+			true,
+			false,
+			true
+		)
 	elseif type == "PRESSED_OR_AXIS" then
-		_ , actionEventId = self:addActionEvent(spec.actionEvents, InputAction[inputAction], self, realismAddon_gearbox_inputs[func], false, false, true, true)
+		_, actionEventId = self:addActionEvent(
+			spec.actionEvents,
+			InputAction[inputAction],
+			self,
+			realismAddon_gearbox_inputs[func],
+			false,
+			false,
+			true,
+			true
+		)
 	end
 	if not showHud then
 		g_inputBinding:setActionEventTextVisibility(actionEventId, false)
 	end
 end
--- END 
--- 
+-- END
+--
 
 -- INPUT CALLBACKS
--- 
+--
 
 -- hand throttle.. not an ideal way of doing it, performancewise..  I think.
-function realismAddon_gearbox_inputs:HANDTHROTTLE_INPUT(actionName, inputValue)	
-
-
+function realismAddon_gearbox_inputs:HANDTHROTTLE_INPUT(actionName, inputValue)
 	local spec = self.spec_realismAddon_gearbox_inputs
 	spec.handThrottleDown = false
-	spec.handThrottleUp = false	
+	spec.handThrottleUp = false
 	if actionName == "RAGB_HANDTHROTTLE_AXIS" then
-	
-		
 		-- round to 1% resolution should be fine enough (to not spam multiplayer synch)
 		inputValue = math.floor(inputValue * 100) / 100
 		if spec.handThrottlePercent ~= inputValue then
@@ -86,69 +103,68 @@ function realismAddon_gearbox_inputs:HANDTHROTTLE_INPUT(actionName, inputValue)
 			spec.handThrottlePercent = inputValue
 		end
 	elseif actionName == "RAGB_HANDTHROTTLE_UP" and inputValue == 1 then
-		spec.handThrottleUp = true 
+		spec.handThrottleUp = true
 	elseif actionName == "RAGB_HANDTHROTTLE_DOWN" and inputValue == 1 then
-		spec.handThrottleDown = true			
+		spec.handThrottleDown = true
 	end
 end
 
 -- shifting axis for fps transmissions
 function realismAddon_gearbox_inputs:RAGB_GEARSHIFT_AXIS(actionName, inputValue)
-
-
 	local input = self.spec_realismAddon_gearbox_inputs
 	local motor = self.spec_motorized.motor
 	local gears = motor.currentGears
-	
-	-- calculate wanted gear as rounded value of all gears * inputValue 
+
+	-- calculate wanted gear as rounded value of all gears * inputValue
 	local wantedGear = math.floor(#gears * inputValue)
-	
+
 	-- only call the event if inputAxis moved enough to be a new gear (motor.gear is the current gear index in FS22)
 	if input.gearAxisPosition ~= wantedGear then
-		if wantedGear ~= motor.gear then 
+		if wantedGear ~= motor.gear then
 			MotorGearShiftEvent.sendToServer(self, MotorGearShiftEvent.TYPE_SELECT_GEAR, wantedGear)
 		end
 		input.gearAxisPosition = wantedGear
 	end
-	
 end
 
--- second group set 
+-- second group set
 function realismAddon_gearbox_inputs:GROUPSECOND_INPUT(actionName, inputValue)
-
 	local spec_ragb = self.spec_realismAddon_gearbox
-	
-	if spec_ragb.groupsSecondSet ~= nil then	
-	
+
+	if spec_ragb.groupsSecondSet ~= nil then
 		local wantedGroup = spec_ragb.groupsSecondSet.currentGroup
+
 		if actionName == "RAGB_GROUPSECOND_UP" then
 			wantedGroup = math.min(spec_ragb.groupsSecondSet.currentGroup + 1, #spec_ragb.groupsSecondSet.groups)
 		elseif actionName == "RAGB_GROUPSECOND_DOWN" then
 			wantedGroup = math.max(spec_ragb.groupsSecondSet.currentGroup - 1, 1)
+		elseif actionName == "RAGB_GROUPSECOND_TWO_OR_ONE" and #spec_ragb.groupsSecondSet.groups == 2 then
+			-- If button pressed (inputValue == 1), switch to H (group 2); if released (inputValue == 0), switch to L (group 1)
+			if inputValue == 1 then
+				wantedGroup = 2
+			else
+				wantedGroup = 1
+			end
 		end
-		
+
 		if wantedGroup ~= spec_ragb.groupsSecondSet.currentGroup then
 			self:processSecondGroupSetInputs(wantedGroup)
 		end
 	end
-
 end
 
 -- handbrake
 function realismAddon_gearbox_inputs:HANDBRAKE_INPUT(actionName, inputValue)
-
 	local spec_ragb = self.spec_realismAddon_gearbox
-	
-	if spec_ragb.handbrakeStateME ~= nil then	
+
+	if spec_ragb.handbrakeStateME ~= nil then
 		self:processHandbrakeInput(not spec_ragb.handbrakeStateME)
 	end
 end
 -- END
 
-
--- group 5 to 8 manual shifting 
+-- group 5 to 8 manual shifting
 function realismAddon_gearbox_inputs:GROUP58_MANUAL_INPUT(actionName, inputValue)
-	
 	local wantedGearGroupIndex = 5
 	if actionName == "RAGB_SHIFT_GROUP_6" then
 		wantedGearGroupIndex = 6
@@ -160,146 +176,133 @@ function realismAddon_gearbox_inputs:GROUP58_MANUAL_INPUT(actionName, inputValue
 
 	local motor = self.spec_motorized.motor
 	if motor.gearGroups[wantedGearGroupIndex] ~= nil then
-		MotorGearShiftEvent.sendToServer(self, MotorGearShiftEvent.TYPE_SELECT_GROUP, inputValue == 1 and wantedGearGroupIndex or 0)
+		MotorGearShiftEvent.sendToServer(
+			self,
+			MotorGearShiftEvent.TYPE_SELECT_GROUP,
+			inputValue == 1 and wantedGearGroupIndex or 0
+		)
 	end
 end
 
--- ACTUAL SPEC 
+-- ACTUAL SPEC
 
 function realismAddon_gearbox_inputs.registerEventListeners(vehicleType)
 	SpecializationUtil.registerEventListener(vehicleType, "onLoad", realismAddon_gearbox_inputs)
 	SpecializationUtil.registerEventListener(vehicleType, "onUpdate", realismAddon_gearbox_inputs)
 	SpecializationUtil.registerEventListener(vehicleType, "onWriteUpdateStream", realismAddon_gearbox_inputs)
 	SpecializationUtil.registerEventListener(vehicleType, "onReadUpdateStream", realismAddon_gearbox_inputs)
-	
+
 	SpecializationUtil.registerEventListener(vehicleType, "onRegisterActionEvents", realismAddon_gearbox_inputs)
-	
 end
 
-function realismAddon_gearbox_inputs.registerFunctions(vehicleType)
-	
-end
+function realismAddon_gearbox_inputs.registerFunctions(vehicleType) end
 
 -- LOAD
 function realismAddon_gearbox_inputs:onLoad(savegame)
-
-	
 	self.addRealismAddonActionEvent = realismAddon_gearbox_inputs.addRealismAddonActionEvent
 
 	self.spec_realismAddon_gearbox_inputs = {}
 	local spec = self.spec_realismAddon_gearbox_inputs
-	
-	-- this value contains an up to date value if we are in manual mode 
+
+	-- this value contains an up to date value if we are in manual mode
 	spec.allManualActive = false
-	
-	-- check if transmission is manual 
+
+	-- check if transmission is manual
 	local allManualActive = realismAddon_gearbox_overrides.checkIsManual(self.spec_motorized.motor)
 	if allManualActive ~= spec.allManualActive then
 		spec.allManualActive = allManualActive
-	end		
-	
+	end
+
 	-- hand throttle values
 	spec.handThrottlePercent = 0
 	spec.handThrottleDown = false
 	spec.handThrottleUp = false
-	
-	spec.synchHandThrottleDirtyFlag = self:getNextDirtyFlag()	
-	
-	-- gear shift axis values 
-	spec.gearAxisPosition = 0	
-	
 
+	spec.synchHandThrottleDirtyFlag = self:getNextDirtyFlag()
 
+	-- gear shift axis values
+	spec.gearAxisPosition = 0
 end
-
-
 
 -- UPDATE
 function realismAddon_gearbox_inputs:onUpdate(dt)
-
 	if self:getIsActive() then
-	
-		local spec = self.spec_realismAddon_gearbox_inputs	
-	
-		-- check if transmission is manual 
+		local spec = self.spec_realismAddon_gearbox_inputs
+
+		-- check if transmission is manual
 		local allManualActive = realismAddon_gearbox_overrides.checkIsManual(self.spec_motorized.motor)
 		if allManualActive ~= spec.allManualActive then
 			spec.allManualActive = allManualActive
 		end
-		
-		
-		if spec.allManualActive then			
-			-- calculating hand throttle 
+
+		if spec.allManualActive then
+			-- calculating hand throttle
 			if spec.handThrottleDown then
-				spec.handThrottlePercent = math.max(0, spec.handThrottlePercent - 0.001*dt)
+				spec.handThrottlePercent = math.max(0, spec.handThrottlePercent - 0.001 * dt)
 				self:raiseDirtyFlags(spec.synchHandThrottleDirtyFlag)
 			elseif spec.handThrottleUp then
-				spec.handThrottlePercent = math.min(1, spec.handThrottlePercent + 0.001*dt)
-				self:raiseDirtyFlags(spec.synchHandThrottleDirtyFlag)				
+				spec.handThrottlePercent = math.min(1, spec.handThrottlePercent + 0.001 * dt)
+				self:raiseDirtyFlags(spec.synchHandThrottleDirtyFlag)
 			end
-
 		end
-			
 	end
-	
 end
 
--- READ AND WRITE UPDATE 
-
+-- READ AND WRITE UPDATE
 
 function realismAddon_gearbox_inputs:onWriteUpdateStream(streamId, connection, dirtyMask)
 	local spec = self.spec_realismAddon_gearbox_inputs
 
-	if connection:getIsServer() and spec.allManualActive then 
+	if connection:getIsServer() and spec.allManualActive then
 		-- hand throttle
 		if streamWriteBool(streamId, bitAND(dirtyMask, spec.synchHandThrottleDirtyFlag) ~= 0) then
 			streamWriteUIntN(streamId, spec.handThrottlePercent * 100, 7)
-		end		
+		end
 	end
-	
 end
 
 function realismAddon_gearbox_inputs:onReadUpdateStream(streamId, timestamp, connection)
 	local spec = self.spec_realismAddon_gearbox_inputs
-	
-	if not connection:getIsServer() and spec.allManualActive then 
+
+	if not connection:getIsServer() and spec.allManualActive then
 		-- hand throttle
 		if streamReadBool(streamId) then
 			spec.handThrottlePercent = streamReadUIntN(streamId, 7) / 100
-		end		
+		end
 	end
-	
 end
 
-
-
--- Bug-Fix for Giants - Default only 7 gear Inputs synchronized in MP but 8 inputs in game 
+-- Bug-Fix for Giants - Default only 7 gear Inputs synchronized in MP but 8 inputs in game
 function realismAddon_gearbox_inputs.MotorGearShiftEvent_readStream(self, superFunc, streamId, connection)
-
 	self.vehicle = NetworkUtil.readNodeObject(streamId)
 	self.shiftType = streamReadUIntN(streamId, 4)
 
-	if self.shiftType == MotorGearShiftEvent.TYPE_SELECT_GEAR or self.shiftType == MotorGearShiftEvent.TYPE_SELECT_GROUP then
-		self.shiftValue = streamReadUIntN(streamId, 5)  -- changed bits from 3 (gear 1-7) to 5 (up to 31 gears possible)
+	if
+		self.shiftType == MotorGearShiftEvent.TYPE_SELECT_GEAR
+		or self.shiftType == MotorGearShiftEvent.TYPE_SELECT_GROUP
+	then
+		self.shiftValue = streamReadUIntN(streamId, 5) -- changed bits from 3 (gear 1-7) to 5 (up to 31 gears possible)
 	end
 
 	self:run(connection)
 end
-MotorGearShiftEvent.readStream = Utils.overwrittenFunction(MotorGearShiftEvent.readStream, realismAddon_gearbox_inputs.MotorGearShiftEvent_readStream)
-
+MotorGearShiftEvent.readStream = Utils.overwrittenFunction(
+	MotorGearShiftEvent.readStream,
+	realismAddon_gearbox_inputs.MotorGearShiftEvent_readStream
+)
 
 function realismAddon_gearbox_inputs.MotorGearShiftEvent_writeStream(self, superFunc, streamId, connection)
-
 	NetworkUtil.writeNodeObject(streamId, self.vehicle)
 	streamWriteUIntN(streamId, self.shiftType, 4)
 
-	if self.shiftType == MotorGearShiftEvent.TYPE_SELECT_GEAR or self.shiftType == MotorGearShiftEvent.TYPE_SELECT_GROUP then
-		streamWriteUIntN(streamId, self.shiftValue, 5)  -- changed bits from 3 (gear 1-7) to 5 (up to 31 gears possible)
+	if
+		self.shiftType == MotorGearShiftEvent.TYPE_SELECT_GEAR
+		or self.shiftType == MotorGearShiftEvent.TYPE_SELECT_GROUP
+	then
+		streamWriteUIntN(streamId, self.shiftValue, 5) -- changed bits from 3 (gear 1-7) to 5 (up to 31 gears possible)
 	end
 end
-MotorGearShiftEvent.writeStream = Utils.overwrittenFunction(MotorGearShiftEvent.writeStream, realismAddon_gearbox_inputs.MotorGearShiftEvent_writeStream)
-
-
-
-
-
+MotorGearShiftEvent.writeStream = Utils.overwrittenFunction(
+	MotorGearShiftEvent.writeStream,
+	realismAddon_gearbox_inputs.MotorGearShiftEvent_writeStream
+)

--- a/realismAddon_gearbox_overrides.lua
+++ b/realismAddon_gearbox_overrides.lua
@@ -1,58 +1,55 @@
 -- by modelleicher ( Farming Agency )
 
-
 realismAddon_gearbox_overrides = {}
 
 local MAX_ACCELERATION_LOAD = 0.8
 
--- completely overwrite getLastModulatedMotorRpm to remove the RPM-lowering effect on load-changes. This seems to be done on purpose by Giants for whatever reason. 
--- I don't think we need anything in that function so just return unmodified lastMotorRpm (to try, maybe return lastRealMotorRpm instead even) 
--- this is active no matter what as soon as this script is active while other functions only activate when MANUAL + CLUTCH setting is active 
+-- completely overwrite getLastModulatedMotorRpm to remove the RPM-lowering effect on load-changes. This seems to be done on purpose by Giants for whatever reason.
+-- I don't think we need anything in that function so just return unmodified lastMotorRpm (to try, maybe return lastRealMotorRpm instead even)
+-- this is active no matter what as soon as this script is active while other functions only activate when MANUAL + CLUTCH setting is active
 function realismAddon_gearbox_overrides.newGetLastModulatedMotorRpm(self, superFunc)
-    return self.lastMotorRpm
+	return self.lastMotorRpm
 end
-VehicleMotor.getLastModulatedMotorRpm = Utils.overwrittenFunction(VehicleMotor.getLastModulatedMotorRpm, realismAddon_gearbox_overrides.newGetLastModulatedMotorRpm)
+VehicleMotor.getLastModulatedMotorRpm = Utils.overwrittenFunction(
+	VehicleMotor.getLastModulatedMotorRpm,
+	realismAddon_gearbox_overrides.newGetLastModulatedMotorRpm
+)
 
+-- gearbox adjustments - notes
 
--- gearbox adjustments - notes 
-
--- remove all automatic braking - done 
--- add auto acceleration below min rpm - done 
--- brake and acc pedal still works fine - done 
--- figure out why rpm is above minRpm now - done 
--- wheel rpm -> diff rpm -> clutch rpm -> motor rpm realignment - done 
+-- remove all automatic braking - done
+-- add auto acceleration below min rpm - done
+-- brake and acc pedal still works fine - done
+-- figure out why rpm is above minRpm now - done
+-- wheel rpm -> diff rpm -> clutch rpm -> motor rpm realignment - done
 -- load add-in when neutral or clutch - done
 -- check clutch engagement how/where what - done
--- add clutch-feel from RMT, make clutch slippable - done 
+-- add clutch-feel from RMT, make clutch slippable - done
 -- hand throttle add in - done
--- added fps axis shifting, analog axis for gear selection - done 
--- check and override pto rpm stuff - done 
--- stop running away when motor off - done 
+-- added fps axis shifting, analog axis for gear selection - done
+-- check and override pto rpm stuff - done
+-- stop running away when motor off - done
 
--- smaller fixes 
--- currentGearRatio set to 0 if in neutral, remove jerking when clutch is released in neutral - done 
--- added smoothing of acceleration value to stabilize rpm and load and lastAcceleratorPedal				 
--- updateGear function seems to be the only one where clutch ratio has influence on gear ratio #M1 - yep, that solved it 
+-- smaller fixes
+-- currentGearRatio set to 0 if in neutral, remove jerking when clutch is released in neutral - done
+-- added smoothing of acceleration value to stabilize rpm and load and lastAcceleratorPedal
+-- updateGear function seems to be the only one where clutch ratio has influence on gear ratio #M1 - yep, that solved it
 
--- things to add and consider	
--- 		work out a way to calculate and interpolate between forward-reverse when vehicle is moving and clutch is pressed to stop vehicle from sudden stop when starting to engage clutch and vehicle rolls in opposite speed 
+-- things to add and consider
+-- 		work out a way to calculate and interpolate between forward-reverse when vehicle is moving and clutch is pressed to stop vehicle from sudden stop when starting to engage clutch and vehicle rolls in opposite speed
 
--- wrong RPM calculation between clutchValue 0.8 and 0.9 -- made clutch completely disengaged at 0.8 solves this.. don't have any other way atm since thats a engine function that returns the wrong value and I don't know which values influence that if any 
+-- wrong RPM calculation between clutchValue 0.8 and 0.9 -- made clutch completely disengaged at 0.8 solves this.. don't have any other way atm since thats a engine function that returns the wrong value and I don't know which values influence that if any
 
--- notes end 
+-- notes end
 
--- second group set ratio calculation  
+-- second group set ratio calculation
 function realismAddon_gearbox_overrides.getGearRatioMultiplier(self, superFunc)
-
-	
 	if realismAddon_gearbox_overrides.checkIsManual(self) then
-	
-		
 		local vehicle = self.vehicle
-		
+
 		local multiplier = superFunc(self)
 		--print(multiplier)
-		
+
 		local spec = vehicle.spec_realismAddon_gearbox
 		if spec ~= nil and spec.groupsSecondSet ~= nil and spec.groupsSecondSet.currentGroup ~= nil then
 			multiplier = multiplier / spec.groupsSecondSet.groups[spec.groupsSecondSet.currentGroup].ratio
@@ -60,18 +57,19 @@ function realismAddon_gearbox_overrides.getGearRatioMultiplier(self, superFunc)
 		return multiplier
 	else
 		return superFunc(self)
-	end	
-
+	end
 end
-VehicleMotor.getGearRatioMultiplier = Utils.overwrittenFunction(VehicleMotor.getGearRatioMultiplier, realismAddon_gearbox_overrides.getGearRatioMultiplier)
+VehicleMotor.getGearRatioMultiplier = Utils.overwrittenFunction(
+	VehicleMotor.getGearRatioMultiplier,
+	realismAddon_gearbox_overrides.getGearRatioMultiplier
+)
 
--- show "P" instead of gear when handbrake is used and active on incab displays 
+-- show "P" instead of gear when handbrake is used and active on incab displays
 function realismAddon_gearbox_overrides.getGearToDisplay(self, superFunc, val, val2, val3, val4, val5)
-
 	local value = superFunc(self, val, val2, val3, val4, val5)
 	if realismAddon_gearbox_overrides.checkIsManual(self) then
 		local spec = self.vehicle.spec_realismAddon_gearbox
-		
+
 		if spec.handbrakeUseME and spec.handbrakeStateME then
 			value = "P"
 		end
@@ -79,299 +77,282 @@ function realismAddon_gearbox_overrides.getGearToDisplay(self, superFunc, val, v
 	return value
 end
 
-VehicleMotor.getGearToDisplay = Utils.overwrittenFunction(VehicleMotor.getGearToDisplay, realismAddon_gearbox_overrides.getGearToDisplay)
+VehicleMotor.getGearToDisplay =
+	Utils.overwrittenFunction(VehicleMotor.getGearToDisplay, realismAddon_gearbox_overrides.getGearToDisplay)
 
 -- show "P" instead of gear when handbrake is used and active on lower right vehicle HUD
 function realismAddon_gearbox_overrides.getGearInfoToDisplay(self, superFunc, val)
-
 	local val1, val2, val3, val4, val5, val6, val7, val8, val9, val10 = superFunc(self, val)
 	--print(tostring(val1).." "..tostring(val2).." "..tostring(val3).." "..tostring(val4).." "..tostring(val5).." "..tostring(val6).." "..tostring(val7).." "..tostring(val8).." "..tostring(val9).." "..tostring(val10))
 	local spec_ragb = self.spec_realismAddon_gearbox
-	
-	if spec_ragb.handbrakeUseME and	spec_ragb.handbrakeStateME then
+
+	if spec_ragb.handbrakeUseME and spec_ragb.handbrakeStateME then
 		val1 = "P"
 	end
 
 	return val1, val2, val3, val4, val5, val6, val7, val8, val9, val10
 end
-Motorized.getGearInfoToDisplay = Utils.overwrittenFunction(Motorized.getGearInfoToDisplay, realismAddon_gearbox_overrides.getGearInfoToDisplay)
+Motorized.getGearInfoToDisplay =
+	Utils.overwrittenFunction(Motorized.getGearInfoToDisplay, realismAddon_gearbox_overrides.getGearInfoToDisplay)
 
-
--- better clutch feel 
+-- better clutch feel
 function realismAddon_gearbox_overrides.calculateClutchRatio(self, motor)
+	local spec = self.spec_realismAddon_gearbox
 
-
-    local spec = self.spec_realismAddon_gearbox
-	
-	-- the end of this function will determine the actual gear ratio 
+	-- the end of this function will determine the actual gear ratio
 	local actualGearRatio = 0
 
-	-- first get the current theoretical gear ratio based on wheel speed 	
+	-- first get the current theoretical gear ratio based on wheel speed
 	local wheelSpeed = 0
 	local numWheels = 0
 	for _, wheel in pairs(self.spec_wheels.wheels) do
-
-		local rpm = getWheelShapeAxleSpeed(wheel.node, wheel.physics.wheelShape)*30/math.pi
+		local rpm = getWheelShapeAxleSpeed(wheel.node, wheel.physics.wheelShape) * 30 / math.pi
 		wheelSpeed = wheelSpeed + (rpm * wheel.physics.radius)
 		numWheels = numWheels + 1
-		
-	end	
+	end
 	wheelSpeed = wheelSpeed / numWheels
-	
-	-- :wheelSpeed is now the signed average speed of all wheels  (FS25 Fix - add 0.00001 to avoid division by 0 error) 
-	-- use that to calculate the current gear ratio 
+
+	-- :wheelSpeed is now the signed average speed of all wheels  (FS25 Fix - add 0.00001 to avoid division by 0 error)
+	-- use that to calculate the current gear ratio
 	local currentGearRatio = math.max(1, motor.lastMotorRpm) / (wheelSpeed + 0.00001)
 
-	-- :currentGearRatio is now the actual true ratio between wheels average and motor 
-	
-	-- cap the currentRatio since if the ratio is too big physics act weird 
+	-- :currentGearRatio is now the actual true ratio between wheels average and motor
+
+	-- cap the currentRatio since if the ratio is too big physics act weird
 	if currentGearRatio < 0 then
 		currentGearRatio = math.max(currentGearRatio, -1000)
 	else
 		currentGearRatio = math.min(currentGearRatio, 1000)
 	end
-	
-	-- get the wanted gear Ratio 
+
+	-- get the wanted gear Ratio
 	local wantedGearRatio = 0
 	if motor.currentGears[motor.gear] ~= nil then
 		wantedGearRatio = motor.currentGears[motor.gear].ratio * motor:getGearRatioMultiplier()
-	end		
+	end
 
-
-	-- if we are in neutral currentGearRatio is set to 0 as well no matter what 
+	-- if we are in neutral currentGearRatio is set to 0 as well no matter what
 	if wantedGearRatio == 0 then
 		currentGearRatio = 0
-	end	
-	
-	-- smoothing maybe 
+	end
+
+	-- smoothing maybe
 	if motor.lastGearRatioME == nil then
 		motor.lastGearRatioME = currentGearRatio
 	end
 	motor.lastGearRatioME = motor.lastGearRatioME * 0.9 + currentGearRatio * 0.1
-	
-	
-	-- clutch value 
-	local manualClutchValue = math.max(motor.manualClutchValue, spec.clutchValueOverride)
-	
-	-- :wantedGearRatio is now the signed wanted ratio 
 
-	-- manualClutchValue is inverted so 0 is closed 1 is open 
+	-- clutch value
+	local manualClutchValue = math.max(motor.manualClutchValue, spec.clutchValueOverride)
+
+	-- :wantedGearRatio is now the signed wanted ratio
+
+	-- manualClutchValue is inverted so 0 is closed 1 is open
 	if manualClutchValue < 0.01 then -- clutch is closed, use wantedGearRatio for actualGearRatio
 		actualGearRatio = wantedGearRatio
-	else -- if clutch is at least partially opened, use the ratio calculation including the clutch value 
-	
-		-- invert back to 0-1 value where 1 is closed 
+	else -- if clutch is at least partially opened, use the ratio calculation including the clutch value
+		-- invert back to 0-1 value where 1 is closed
 		local manualClutchValueInvert = 1 - manualClutchValue
-		
+
 		-- clutch non-linear and cap at 1
-		manualClutchValueInvert = math.min(manualClutchValueInvert * manualClutchValueInvert, 1)		
-		
-		-- interpolate between wanted and actual ratio according to clutch value 
-		actualGearRatio = (wantedGearRatio * manualClutchValueInvert) + (motor.lastGearRatioME * (1-manualClutchValueInvert))
-		
-		-- cap actual ratio at wanted 
+		manualClutchValueInvert = math.min(manualClutchValueInvert * manualClutchValueInvert, 1)
+
+		-- interpolate between wanted and actual ratio according to clutch value
+		actualGearRatio = (wantedGearRatio * manualClutchValueInvert)
+			+ (motor.lastGearRatioME * (1 - manualClutchValueInvert))
+
+		-- cap actual ratio at wanted
 		if wantedGearRatio < 0 then
-			-- smaller negative value = higher ratio so cap at min 
+			-- smaller negative value = higher ratio so cap at min
 			actualGearRatio = math.min(actualGearRatio, wantedGearRatio)
 		else
 			actualGearRatio = math.max(actualGearRatio, wantedGearRatio)
 		end
-		
-		-- TO DO :instead of using wanted as cap, calculate ratio when wanted is another direction than actual such that vehicle slows down and accelerates in opposite direction at a realistic feeling rate 
-			
+
+		-- TO DO :instead of using wanted as cap, calculate ratio when wanted is another direction than actual such that vehicle slows down and accelerates in opposite direction at a realistic feeling rate
 	end
-	
 
 	motor.maxGearRatio = actualGearRatio
 	motor.minGearRatio = actualGearRatio
-
 end
 
--- function to return if vehicle and settings are manual 
+-- function to return if vehicle and settings are manual
 function realismAddon_gearbox_overrides.checkIsManual(motor)
-	local isManualTransmission = motor.backwardGears ~= nil or motor.forwardGears ~= nil	
-	if isManualTransmission and motor.gearShiftMode == VehicleMotor.SHIFT_MODE_MANUAL_CLUTCH or isManualTransmission and  motor.gearShiftMode == VehicleMotor.SHIFT_MODE_MANUAL then	
+	local isManualTransmission = motor.backwardGears ~= nil or motor.forwardGears ~= nil
+	if
+		isManualTransmission and motor.gearShiftMode == VehicleMotor.SHIFT_MODE_MANUAL_CLUTCH
+		or isManualTransmission and motor.gearShiftMode == VehicleMotor.SHIFT_MODE_MANUAL
+	then
 		return true
 	else
 		return false
 	end
 end
 
--- remove ptoRpm to minRpm change 
+-- remove ptoRpm to minRpm change
 function realismAddon_gearbox_overrides.getRequiredMotorRpmRange(self, superFunc)
-	
 	if realismAddon_gearbox_overrides.checkIsManual(self) then
 		return self.minRpm, self.maxRpm
 	else
 		return superFunc(self)
 	end
-
 end
-VehicleMotor.getRequiredMotorRpmRange = Utils.overwrittenFunction(VehicleMotor.getRequiredMotorRpmRange, realismAddon_gearbox_overrides.getRequiredMotorRpmRange)
-
+VehicleMotor.getRequiredMotorRpmRange = Utils.overwrittenFunction(
+	VehicleMotor.getRequiredMotorRpmRange,
+	realismAddon_gearbox_overrides.getRequiredMotorRpmRange
+)
 
 -- VehicleMotor.update
 function realismAddon_gearbox_overrides.update(self, superFunc, dt)
-
-
 	-- do our custom stuff only if we are in SHIFT_MODE_MANUAL_CLUTCH and in a vehicle with manual transmission
-	if realismAddon_gearbox_overrides.checkIsManual(self) then	
-		
+	if realismAddon_gearbox_overrides.checkIsManual(self) then
 		local vehicle = self.vehicle
-		
-		-- base stuff 
+
+		-- base stuff
 		if next(vehicle.spec_motorized.differentials) ~= nil and vehicle.spec_motorized.motorizedNode ~= nil then
 			local lastMotorRotSpeed = self.motorRotSpeed
 			local lastDiffRotSpeed = self.differentialRotSpeed
-			self.motorRotSpeed, self.differentialRotSpeed, self.gearRatio = getMotorRotationSpeed(vehicle.spec_motorized.motorizedNode)
-			
+			self.motorRotSpeed, self.differentialRotSpeed, self.gearRatio =
+				getMotorRotationSpeed(vehicle.spec_motorized.motorizedNode)
+
 			--print(tostring(self.motorRotSpeed)..tostring(self.differentialRotSpeed)..tostring(self.gearRatio))
 			--print("############################################################################")
-			
-			-- if clutch is disengaged more than 80% getMotorRotationSpeed will return wrong values for the motor rot speed, it will always return max rpm not sure why 
-				
-			
+
+			-- if clutch is disengaged more than 80% getMotorRotationSpeed will return wrong values for the motor rot speed, it will always return max rpm not sure why
+
 			if g_physicsDtNonInterpolated > 0 and not getIsSleeping(vehicle.rootNode) then
-				self.lastMotorAvailableTorque, self.lastMotorAppliedTorque, self.lastMotorExternalTorque = getMotorTorque(vehicle.spec_motorized.motorizedNode)
+				self.lastMotorAvailableTorque, self.lastMotorAppliedTorque, self.lastMotorExternalTorque =
+					getMotorTorque(vehicle.spec_motorized.motorizedNode)
 			end
 
-
-			local motorRotAcceleration = ((self.motorRotSpeed - lastMotorRotSpeed)+0.00001) / ((g_physicsDtNonInterpolated * 0.001)+0.00001) 	-- FS25 Fix add 0.00001 to avoid division by 0 error 
+			local motorRotAcceleration = ((self.motorRotSpeed - lastMotorRotSpeed) + 0.00001)
+				/ ((g_physicsDtNonInterpolated * 0.001) + 0.00001) -- FS25 Fix add 0.00001 to avoid division by 0 error
 			self.motorRotAcceleration = motorRotAcceleration
 			self.motorRotAccelerationSmoothed = 0.8 * self.motorRotAccelerationSmoothed + 0.2 * motorRotAcceleration
-			
+
 			local diffRotAcc = 0
 			self.differentialRotAcceleration = 0
 			if self.differentialRotSpeed ~= 0 and lastDiffRotSpeed ~= 0 then
-				local diffRotAcc = ((self.differentialRotSpeed - lastDiffRotSpeed)+0.00001) / ((g_physicsDtNonInterpolated * 0.001)+0.00001) 	-- FS25 Fix add 0.00001 to avoid division by 0 error 
+				local diffRotAcc = ((self.differentialRotSpeed - lastDiffRotSpeed) + 0.00001)
+					/ ((g_physicsDtNonInterpolated * 0.001) + 0.00001) -- FS25 Fix add 0.00001 to avoid division by 0 error
 				self.differentialRotAcceleration = diffRotAcc
 			end
-			
-			self.differentialRotAccelerationSmoothed = 0.95 * self.differentialRotAccelerationSmoothed + 0.05 * diffRotAcc	
-		
-		
+
+			self.differentialRotAccelerationSmoothed = 0.95 * self.differentialRotAccelerationSmoothed
+				+ 0.05 * diffRotAcc
 
 			self.motorExternalTorque = self.lastMotorExternalTorque
 			self.motorAppliedTorque = self.lastMotorAppliedTorque
 			self.motorAvailableTorque = self.lastMotorAvailableTorque
-			
-			self.motorAppliedTorque = self.motorAppliedTorque - self.motorExternalTorque	
-			self.motorExternalTorque = math.min(self.motorExternalTorque * self.externalTorqueVirtualMultiplicator, self.motorAvailableTorque - self.motorAppliedTorque)			
+
+			self.motorAppliedTorque = self.motorAppliedTorque - self.motorExternalTorque
+			self.motorExternalTorque = math.min(
+				self.motorExternalTorque * self.externalTorqueVirtualMultiplicator,
+				self.motorAvailableTorque - self.motorAppliedTorque
+			)
 			self.motorAppliedTorque = self.motorAppliedTorque + self.motorExternalTorque
-			
+
 			self.requiredMotorPower = math.huge
-			
 		else
 			local _, gearRatio = self:getMinMaxGearRatio()
 			self.differentialRotSpeed = WheelsUtil.computeDifferentialRotSpeedNonMotor(vehicle)
 			self.motorRotSpeed = math.max(math.abs(self.differentialRotSpeed * gearRatio), 0)
 			self.gearRatio = gearRatio
 		end
-		
-		local clampedMotorRpm = math.max(self.motorRotSpeed*30/math.pi, self.minRpm)
-		
+
+		local clampedMotorRpm = math.max(self.motorRotSpeed * 30 / math.pi, self.minRpm)
 
 		-- lastMotorRpm is smoothed
-		-- lastRealMotorRpm is not smoothed 
-		
-		-- take additional clutch value overrides into account 
-		local manualClutchValue = math.max(self.manualClutchValue, vehicle.spec_realismAddon_gearbox.clutchValueOverride)
-				
-		-- modelleicher 
-		-- if clutch is pressed, motor RPM is not dependent on wheel speed anymore.. Instead, calculate motor RPM based on accelerator pedal input 
-		if manualClutchValue > 0.1 or self:getIsInNeutral() then		
-			
+		-- lastRealMotorRpm is not smoothed
+
+		-- take additional clutch value overrides into account
+		local manualClutchValue =
+			math.max(self.manualClutchValue, vehicle.spec_realismAddon_gearbox.clutchValueOverride)
+
+		-- modelleicher
+		-- if clutch is pressed, motor RPM is not dependent on wheel speed anymore.. Instead, calculate motor RPM based on accelerator pedal input
+		if manualClutchValue > 0.1 or self:getIsInNeutral() then
 			local clutchPercent = 1 - manualClutchValue
-			
+
 			if self:getIsInNeutral() then
 				clutchPercent = 0
 			end
-			
+
 			local accInput = 0
 			if vehicle.getAxisForward ~= nil then
 				accInput = math.max(0, vehicle:getAxisForward())
 			end
-			
+
 			-- take hand throttle into account -- TO DO
-			if vehicle.spec_realismAddon_gearbox_inputs ~= nil then	
+			if vehicle.spec_realismAddon_gearbox_inputs ~= nil then
 				accInput = math.max(accInput, vehicle.spec_realismAddon_gearbox_inputs.handThrottlePercent)
 			end
-			
 
 			local wantedRpm = (self.maxRpm - self.minRpm) * accInput + self.minRpm
 			local currentRpm = self.lastRealMotorRpm
 			if currentRpm < wantedRpm then
-				currentRpm = math.min(currentRpm + 2 * dt, wantedRpm)  -- to do, do proper engine rpm increase calculation 
+				currentRpm = math.min(currentRpm + 2 * dt, wantedRpm) -- to do, do proper engine rpm increase calculation
 			elseif currentRpm > wantedRpm then
 				currentRpm = math.max(currentRpm - 1 * dt, wantedRpm)
-			end	
+			end
 
-			
 			if clutchPercent < 0.2 then -- below 20% the clutch is fully opened, just use our RPM calculation    -- 0.8 manual clutch value -
 				clampedMotorRpm = currentRpm
-	
-			elseif clutchPercent < 0.8 then -- up to 80% the clutch can still slip a lot, use fixed percentage 	-- 0.2 manual clutch value 
+			elseif clutchPercent < 0.8 then -- up to 80% the clutch can still slip a lot, use fixed percentage 	-- 0.2 manual clutch value
 				clampedMotorRpm = (clampedMotorRpm * 0.1) + (currentRpm * 0.9)
-				
-			else	-- everything else 
-				clampedMotorRpm = (clampedMotorRpm * ((clutchPercent-0.2)*1.25)) + (currentRpm * (1-((clutchPercent-0.2)*1.25)))
-			end			
-			
+			else -- everything else
+				clampedMotorRpm = (clampedMotorRpm * ((clutchPercent - 0.2) * 1.25))
+					+ (currentRpm * (1 - ((clutchPercent - 0.2) * 1.25)))
+			end
 		else
-		
 			-- get clutch RPM shut off motor if RPM gets too low , disable "auto clutch" of FS
-			local clutchRpm = math.abs(self:getClutchRotSpeed() *  9.5493)
-			
+			local clutchRpm = math.abs(self:getClutchRotSpeed() * 9.5493)
+
 			-- set rpm to clutch rpm if clutch rpm is smaller than min rpm (this doesn't work on Multiplayer)
-			if clutchRpm < self.minRpm and clutchRpm > 0 then -- only if not 0 cause Multiplayer 
+			if clutchRpm < self.minRpm and clutchRpm > 0 then -- only if not 0 cause Multiplayer
 				clampedMotorRpm = (self.lastRealMotorRpm * 0.7) + (clutchRpm * 0.3)
-			end		
-			
-			
-			-- this doesn't work like that in FS22, so disable for now. Set clampedMotorRpm to minRpm if vehicle is stopped anyways 
-			if clutchRpm <= 0 and vehicle.isServer then -- check if we're server 
+			end
+
+			-- this doesn't work like that in FS22, so disable for now. Set clampedMotorRpm to minRpm if vehicle is stopped anyways
+			if clutchRpm <= 0 and vehicle.isServer then -- check if we're server
 				--vehicle:stopMotor()
 				clampedMotorRpm = self.minRpm
 			end
-			
-			-- same as above 
+
+			-- same as above
 			if clampedMotorRpm <= 0 then
 				--vehicle:stopMotor()
 				clampedMotorRpm = self.minRpm
 				self.lastRealMotorRpm = self.minRpm
 			end
 
-			-- clamp so no negative value 
-			clampedMotorRpm = math.max(clampedMotorRpm, 0)	
-
+			-- clamp so no negative value
+			clampedMotorRpm = math.max(clampedMotorRpm, 0)
 		end
-		
-		-- finally set the new RPM values
-		if vehicle.isServer then	
 
-			-- setLastRpm does have some smoothing included 	
-			-- we do some smoothing before anyways because otherwise it will false-register fast rpm changes and inject load 
-			-- TO DO :check if we deactivate the smoothing on dedicated servers because due to synching its all slower anyways and already reacts slower than we want 
+		-- finally set the new RPM values
+		if vehicle.isServer then
+			-- setLastRpm does have some smoothing included
+			-- we do some smoothing before anyways because otherwise it will false-register fast rpm changes and inject load
+			-- TO DO :check if we deactivate the smoothing on dedicated servers because due to synching its all slower anyways and already reacts slower than we want
 			if self.clampedMotorRpm == nil then
 				self.clampedMotorRpm = clampedMotorRpm
 			end
 			self.clampedMotorRpm = self.clampedMotorRpm * 0.6 + clampedMotorRpm * 0.4
-			
-			-- set last rpm 
+
+			-- set last rpm
 			self:setLastRpm(self.clampedMotorRpm)
 
-			self.lastPtoRpm = self.clampedMotorRpm			
-		
-			-- for the equalizedMotorRpm we want heavy smoothing still, though not sure what equalizedMotorRpm is used for in Fs22 I don't think much, maybe in multiplayer  
-			self.equalizedMotorRpm = (self.equalizedMotorRpm * 0.9) + ( 0.1 * clampedMotorRpm)
-		end		
-	
-		
+			self.lastPtoRpm = self.clampedMotorRpm
+
+			-- for the equalizedMotorRpm we want heavy smoothing still, though not sure what equalizedMotorRpm is used for in Fs22 I don't think much, maybe in multiplayer
+			self.equalizedMotorRpm = (self.equalizedMotorRpm * 0.9) + (0.1 * clampedMotorRpm)
+		end
+
 		if vehicle.isServer then
-		
-			-- load calculation by Giants, this doesn't look bad at all 
-			
-			-- raw and buffer 
+			-- load calculation by Giants, this doesn't look bad at all
+
+			-- raw and buffer
 			local rawLoadPercentage = self:getMotorAppliedTorque() / math.max(self:getMotorAvailableTorque(), 0.0001)
 			self.rawLoadPercentageBuffer = self.rawLoadPercentageBuffer + rawLoadPercentage
 			self.rawLoadPercentageBufferIndex = self.rawLoadPercentageBufferIndex + 1
@@ -380,32 +361,36 @@ function realismAddon_gearbox_overrides.update(self, superFunc, dt)
 			if self.rawLoadPercentage >= 0.5 then
 				buffersize = 2
 			end
-			
+
 			if self.rawLoadPercentageBufferIndex >= buffersize then
 				self.rawLoadPercentage = self.rawLoadPercentageBuffer / buffersize
 				self.rawLoadPercentageBuffer = 0
 				self.rawLoadPercentageBufferIndex = 0
 			end
-			
-			-- downhill / push 
-			if self.rawLoadPercentage < 0.01 and self.lastAcceleratorPedal < 0.2 and (not self.backwardGears and not self.forwardGears or self.gear ~= 0 or self.targetGear == 0) then
+
+			-- downhill / push
+			if
+				self.rawLoadPercentage < 0.01
+				and self.lastAcceleratorPedal < 0.2
+				and (not self.backwardGears and not self.forwardGears or self.gear ~= 0 or self.targetGear == 0)
+			then
 				self.rawLoadPercentage = -1
 			else
-				-- min idle load 
+				-- min idle load
 				local idleLoadPct = 0.05
 				self.rawLoadPercentage = (self.rawLoadPercentage - idleLoadPct) / (1 - idleLoadPct)
 			end
-			
+
 			-- modelleicher
-			-- add in load percentage if engine is accelerating in neutral or with clutch pressed 
+			-- add in load percentage if engine is accelerating in neutral or with clutch pressed
 			local clutchPercent = 1 - manualClutchValue
 			local currentRpm = self.lastRealMotorRpm
 			local mAxisForward = 0
 			if vehicle.getAxisForward ~= nil then
 				mAxisForward = math.max(0, vehicle:getAxisForward())
-			end			
-			
-			-- if clutch is pressed or neutral, load percentage is calculated using wanted and actual RPM 
+			end
+
+			-- if clutch is pressed or neutral, load percentage is calculated using wanted and actual RPM
 			if clutchPercent < 0.6 or self:getIsInNeutral() then
 				local loadNeutral
 				if (currentRpm / self.maxRpm) < mAxisForward then
@@ -414,12 +399,15 @@ function realismAddon_gearbox_overrides.update(self, superFunc, dt)
 					loadNeutral = 0
 				end
 				self.rawLoadPercentage = math.max(self.rawLoadPercentage, loadNeutral)
-			end	
-			
-			-- modelleicher end 
-			
-			-- Giants add in acceleration percentage, I think this is something that would've improved load calc in RMT 
-			local accelerationPercentage = math.min(self.vehicle.lastSpeedAcceleration * 1000 * 1000 * self.vehicle.movingDirection / self.accelerationLimit, 1)
+			end
+
+			-- modelleicher end
+
+			-- Giants add in acceleration percentage, I think this is something that would've improved load calc in RMT
+			local accelerationPercentage = math.min(
+				self.vehicle.lastSpeedAcceleration * 1000 * 1000 * self.vehicle.movingDirection / self.accelerationLimit,
+				1
+			)
 
 			if accelerationPercentage < 0.95 and self.lastAcceleratorPedal > 0.2 then
 				self.accelerationLimitLoadScale = 1
@@ -431,17 +419,20 @@ function realismAddon_gearbox_overrides.update(self, superFunc, dt)
 			end
 
 			if accelerationPercentage > 0 then
-				self.rawLoadPercentage = math.max(self.rawLoadPercentage, accelerationPercentage * self.accelerationLimitLoadScale)
+				self.rawLoadPercentage =
+					math.max(self.rawLoadPercentage, accelerationPercentage * self.accelerationLimitLoadScale)
 			end
-			
 
-			self.constantAccelerationCharge = 1 - math.min(math.abs(self.vehicle.lastSpeedAcceleration) * 1000 * 1000 / self.accelerationLimit, 1)
+			self.constantAccelerationCharge = 1
+				- math.min(math.abs(self.vehicle.lastSpeedAcceleration) * 1000 * 1000 / self.accelerationLimit, 1)
 
 			if (self.backwardGears or self.forwardGears) and self:getUseAutomaticGearShifting() then
 				if self.constantRpmCharge > 0.99 then
 					if self.maxRpm - clampedMotorRpm < 50 then
-						self.gearChangeTimeAutoReductionTimer = math.min(self.gearChangeTimeAutoReductionTimer + dt, self.gearChangeTimeAutoReductionTime)
-						self.gearChangeTime = self.gearChangeTimeOrig * (1 - self.gearChangeTimeAutoReductionTimer / self.gearChangeTimeAutoReductionTime)
+						self.gearChangeTimeAutoReductionTimer =
+							math.min(self.gearChangeTimeAutoReductionTimer + dt, self.gearChangeTimeAutoReductionTime)
+						self.gearChangeTime = self.gearChangeTimeOrig
+							* (1 - self.gearChangeTimeAutoReductionTimer / self.gearChangeTimeAutoReductionTime)
 					else
 						self.gearChangeTimeAutoReductionTimer = 0
 						self.gearChangeTime = self.gearChangeTimeOrig
@@ -453,186 +444,184 @@ function realismAddon_gearbox_overrides.update(self, superFunc, dt)
 			end
 
 			if self.rawLoadPercentage > 0 then
-				self.rawLoadPercentage = self.rawLoadPercentage * MAX_ACCELERATION_LOAD + self.rawLoadPercentage * (1 - MAX_ACCELERATION_LOAD) * self.constantAccelerationCharge
-			end		
-			
+				self.rawLoadPercentage = self.rawLoadPercentage * MAX_ACCELERATION_LOAD
+					+ self.rawLoadPercentage * (1 - MAX_ACCELERATION_LOAD) * self.constantAccelerationCharge
+			end
 		end
 
-		self:updateSmoothLoadPercentage(dt, self.rawLoadPercentage)	
-		
+		self:updateSmoothLoadPercentage(dt, self.rawLoadPercentage)
+
 		if vehicle:getIsMotorStarted() then
-		
-			-- turbo calculation for blow-off and turbo sound 		
+			-- turbo calculation for blow-off and turbo sound
 			local accInput = 0
 			if vehicle.getAxisForward ~= nil then
 				accInput = math.max(0, vehicle:getAxisForward())
 			end
-			if vehicle.spec_realismAddon_gearbox_inputs ~= nil then	
+			if vehicle.spec_realismAddon_gearbox_inputs ~= nil then
 				accInput = math.max(accInput, vehicle.spec_realismAddon_gearbox_inputs.handThrottlePercent)
 			end
-			
+
 			local wantedRpm = (self.maxRpm - self.minRpm) * accInput + self.minRpm
 			local currentRpm = self.lastRealMotorRpm
-			
-			local differenceUnsigned =  math.min(wantedRpm, currentRpm) / math.max(wantedRpm, currentRpm)
+
+			local differenceUnsigned = math.min(wantedRpm, currentRpm) / math.max(wantedRpm, currentRpm)
 
 			local sign = -1
 			if (wantedRpm - 50) > currentRpm then
 				sign = 1
 			end
-			
+
 			if self.boostPressureME == nil then
 				self.boostPressureME = 0
 			end
-			
+
 			local boostPressureChangeSpeed = 0.03
-			
+
 			if sign == 1 then
-				self.boostPressureME = math.min(self.boostPressureME + (boostPressureChangeSpeed * differenceUnsigned * (self.minRpm / self.maxRpm)), 1)
+				self.boostPressureME = math.min(
+					self.boostPressureME + (boostPressureChangeSpeed * differenceUnsigned * (self.minRpm / self.maxRpm)),
+					1
+				)
 			else
-				self.boostPressureME = math.max(self.boostPressureME - (boostPressureChangeSpeed * differenceUnsigned * (self.minRpm / self.maxRpm)), 0)		
+				self.boostPressureME = math.max(
+					self.boostPressureME - (boostPressureChangeSpeed * differenceUnsigned * (self.minRpm / self.maxRpm)),
+					0
+				)
 			end
-		
 		else
 			self.boostPressureME = 0
 			self.blowOffValveStateME = 0
-		end		
-		
-			
-		if accInput == 0 or self:getIsInNeutral() or manualClutchValue > 0.8 or self.minGearRatio == 0 and self.autoGearChangeTime > 0 then
+		end
+
+		if
+			accInput == 0
+			or self:getIsInNeutral()
+			or manualClutchValue > 0.8
+			or self.minGearRatio == 0 and self.autoGearChangeTime > 0
+		then
 			self.blowOffValveStateME = self.boostPressureME
 		else
 			self.blowOffValveStateME = 0
-		end		
-				
-				
-		-- fix for automatic gearbox 	
+		end
+
+		-- fix for automatic gearbox
 		if self.forwardGears or self.backwardGears then
 			self:updateStartGearValues(dt)
 		end
-		
-		
-		-- lastSmoothedClutchPedal is used for the clutch animation 
+
+		-- lastSmoothedClutchPedal is used for the clutch animation
 		if self.lastSmoothedClutchPedal ~= nil then
 			local clutchPedal = self:getClutchPedal()
 			self.lastSmoothedClutchPedal = self.lastSmoothedClutchPedal * 0.9 + clutchPedal * 0.1
 		end
-		
-
 	else
 		return superFunc(self, dt)
 	end
-	
 end
 VehicleMotor.update = Utils.overwrittenFunction(VehicleMotor.update, realismAddon_gearbox_overrides.update)
 
-
-
-
-
-function realismAddon_gearbox_overrides.updateWheelsPhysics(self, superFunc, dt, currentSpeed, acceleration, doHandbrake, stopAndGoBraking)
-	
-
+function realismAddon_gearbox_overrides.updateWheelsPhysics(
+	self,
+	superFunc,
+	dt,
+	currentSpeed,
+	acceleration,
+	doHandbrake,
+	stopAndGoBraking
+)
 	-- do our custom stuff only if we are in SHIFT_MODE_MANUAL_CLUTCH and in a vehicle with manual transmission
-	if realismAddon_gearbox_overrides.checkIsManual(self.spec_motorized.motor) then		
-	
+	if realismAddon_gearbox_overrides.checkIsManual(self.spec_motorized.motor) then
 		local motor = self.spec_motorized.motor
-		local spec =self.spec_realismAddon_gearbox
-	
-		-- back up acceleration variable before we do any changes to it, we need this later for braking 
+		local spec = self.spec_realismAddon_gearbox
+
+		-- back up acceleration variable before we do any changes to it, we need this later for braking
 		local accBackup = acceleration
-		
-		-- acc and brake pedal init 
+
+		-- acc and brake pedal init
 		local acceleratorPedal = 0
-		local brakePedal = 0	
-		
-		-- take additional clutch value overrides into account 
-		local manualClutchValue = math.max(motor.manualClutchValue, spec.clutchValueOverride)		
-		
-		
+		local brakePedal = 0
+
+		-- take additional clutch value overrides into account
+		local manualClutchValue = math.max(motor.manualClutchValue, spec.clutchValueOverride)
+
 		--
 		local handThrottlePercent = 0
-		if self.spec_realismAddon_gearbox_inputs ~= nil then	
+		if self.spec_realismAddon_gearbox_inputs ~= nil then
 			handThrottlePercent = self.spec_realismAddon_gearbox_inputs.handThrottlePercent
-		end		
+		end
 		--
-		
+
 		local newWantedAcceleration = 0
-		-- use acceleration as rpm setting 
-		if acceleration >= 0 then -- we are not braking 
-		
-			-- if hand throttle is more than acceleration, use hand throttle value 
+		-- use acceleration as rpm setting
+		if acceleration >= 0 then -- we are not braking
+			-- if hand throttle is more than acceleration, use hand throttle value
 			acceleration = math.max(acceleration, handThrottlePercent)
-			
+
 			-- calculate the currently wanted RPM depending on acceleration (e.g. pedal position)
 			local wantedRpm = (motor.maxRpm - motor.minRpm) * acceleration + motor.minRpm
-			
-			
+
 			-- if our wantedRPM is higher than the currentRPM, increase acceleration, if its lower, decrease acceleration
 			if wantedRpm > motor.lastRealMotorRpm then
 				newWantedAcceleration = 1
 			else
 				newWantedAcceleration = 0
 			end
-		
 		end
-		
+
 		acceleration = newWantedAcceleration
-		
+
 		-- if engine rpm falls below minRpm acceleration is 1
-		if acceleration >= 0 and motor.lastRealMotorRpm <= (motor.minRpm +2) then
+		if acceleration >= 0 and motor.lastRealMotorRpm <= (motor.minRpm + 2) then
 			acceleration = 1
-		end	
-		
+		end
+
 		-- if clutch is disengaged, acceleration is 0
 		if manualClutchValue > 0.8 then
 			acceleration = 0
 		end
 
-		-- if motor is off, no acceleration 
+		-- if motor is off, no acceleration
 		if not self:getIsMotorStarted() then
 			acceleration = 0
 		end
-		
+
 		-- if we are in neutral, acceleration is 0
-		local accelerationNoNeutral = acceleration  -- automatic transmission fix 
+		local accelerationNoNeutral = acceleration -- automatic transmission fix
 		if motor:getIsInNeutral() then
 			acceleration = 0
-		end		
+		end
 
 		-- smoothing acceleration (V 0.5.1.0 addition)
 		if motor.lastAccelerationME == nil then
 			motor.lastAccelerationME = acceleration
 		end
 		motor.lastAccelerationME = motor.lastAccelerationME * 0.9 + acceleration * 0.1
-		
 
-		-- set accelerationPedal desired value 
+		-- set accelerationPedal desired value
 		if acceleration > 0 then
 			acceleratorPedal = acceleration
 		end
 
-		
-		-- set brake pedal desired value  
+		-- set brake pedal desired value
 		if accBackup < 0 then
 			brakePedal = math.abs(accBackup)
 		end
-		-- 		
-		
+		--
+
 		-- hand brake basegame
 		if doHandbrake then
 			brakePedal = 1
 		end
 
 		-- handbrake RAGB (only use then Enhanced Vehicle is not active)
-		if self.spec_realismAddon_gearbox.handbrakeStateME ~= nil and self.vData == nil  then
+		if self.spec_realismAddon_gearbox.handbrakeStateME ~= nil and self.vData == nil then
 			if self.spec_realismAddon_gearbox.handbrakeStateME then
 				brakePedal = 1
 				doHandbrake = true
 			end
 		end
-		
-		-- Enhanced Vehicle Handbrake if Enhanced Vehicle is active 
+
+		-- Enhanced Vehicle Handbrake if Enhanced Vehicle is active
 		if self.vData ~= nil then
 			if self.vData.is[13] then
 				brakePedal = 1
@@ -640,77 +629,80 @@ function realismAddon_gearbox_overrides.updateWheelsPhysics(self, superFunc, dt,
 			end
 			self.spec_realismAddon_gearbox.handbrakeUseME = false
 		end
-		
-																
-		-- fix for automatic gear shifting in the new valtra tractors 
-		-- motor:updateGear does not auto shift in reverse when accelerationPedal is bigger than brakePedal 
-		
+
+		-- fix for automatic gear shifting in the new valtra tractors
+		-- motor:updateGear does not auto shift in reverse when accelerationPedal is bigger than brakePedal
+
 		if not motor:getUseAutomaticGearShifting() and not motor:getUseAutomaticGroupShifting() then
 			acceleratorPedal, brakePedal = motor:updateGear(acceleratorPedal, brakePedal, dt)
 		else
-			-- auto acc pedal including direction 
-			local acceleratorPedalAuto = accelerationNoNeutral * motor.currentDirection -- automatic transmission fix . acc no neutral 
+			-- auto acc pedal including direction
+			local acceleratorPedalAuto = accelerationNoNeutral * motor.currentDirection -- automatic transmission fix . acc no neutral
 			local brakePedalAuto = brakePedal
-			-- if acc pedal is below 0, acc is 0 and brake is absolute of acc 
+			-- if acc pedal is below 0, acc is 0 and brake is absolute of acc
 			if acceleratorPedalAuto < 0 then
 				acceleratorPedalAuto = 0
-				brakePedalAuto = math.abs(acceleratorPedal)				
+				brakePedalAuto = math.abs(acceleratorPedal)
 			end
-			-- call updateGear with modified acc and brake pedals 
-			local acceleratorPedalA, brakePedalA = motor:updateGear(acceleratorPedalAuto, brakePedalAuto, dt)	
-			
-			-- open clutch on fully automatic transmissions when stopping (so either gears and groups automatic or gears automatic and no groups exist)
-			if motor:getUseAutomaticGearShifting() and (motor:getUseAutomaticGroupShifting() and motor.numGearGroups ~= nil or motor.numGearGroups == nil) then
+			-- call updateGear with modified acc and brake pedals
+			local acceleratorPedalA, brakePedalA = motor:updateGear(acceleratorPedalAuto, brakePedalAuto, dt)
 
-				if self:getLastSpeed() < 3 and accBackup <= 0 then 
+			-- open clutch on fully automatic transmissions when stopping (so either gears and groups automatic or gears automatic and no groups exist)
+			if
+				motor:getUseAutomaticGearShifting()
+				and (motor:getUseAutomaticGroupShifting() and motor.numGearGroups ~= nil or motor.numGearGroups == nil)
+			then
+				if self:getLastSpeed() < 3 and accBackup <= 0 then
 					spec.clutchValueOverride = 1
 				else
 					spec.clutchValueOverride = 0
-				end		
-				
+				end
 			end
-			
+
 			-- "fix" the return values to work with the rest of realismAddon_gearbox_overrides
 			if acceleratorPedalAuto < 0 then
 				acceleratorPedal = brakePedalA
 				brakePedalA = brakePedal
 			end
 		end
-		
 
-		-- #M1  -- in updateGear the current clutch ratio influences the current gear ratio 
-				-- also it seems to be only called here, so instead of overwriting the entire function I can just do a new ratio calculation here 		
-		
-		-- better clutch feel, new ratio calc 
+		-- #M1  -- in updateGear the current clutch ratio influences the current gear ratio
+		-- also it seems to be only called here, so instead of overwriting the entire function I can just do a new ratio calculation here
+
+		-- better clutch feel, new ratio calc
 		realismAddon_gearbox_overrides.calculateClutchRatio(self, motor)
-		
+
 		-- smoothing for lastAcceleratorPedal since the acceleratorPedal is on/off with my calculation, even with smoothing the load-changes are too fast (V 0.5.1.0 addition)
 		if motor.lastAcceleratorPedalME == nil then
-			motor.lastAcceleratorPedalME = motor.lastAcceleratorPedal  
+			motor.lastAcceleratorPedalME = motor.lastAcceleratorPedal
 		end
 		motor.lastAcceleratorPedalME = motor.lastAcceleratorPedalME * 0.9 + acceleratorPedal * 0.1
-		
-		motor.lastAcceleratorPedal = motor.lastAcceleratorPedalME												  
-							
 
-		SpecializationUtil.raiseEvent(self, "onVehiclePhysicsUpdate", acceleratorPedal, brakePedal, automaticBrake, currentSpeed)
+		motor.lastAcceleratorPedal = motor.lastAcceleratorPedalME
 
+		SpecializationUtil.raiseEvent(
+			self,
+			"onVehiclePhysicsUpdate",
+			acceleratorPedal,
+			brakePedal,
+			automaticBrake,
+			currentSpeed
+		)
 
-		--acceleratorPedal, brakePedal = WheelsUtil.getSmoothedAcceleratorAndBrakePedals(self, acceleratorPedal, brakePedal, dt)		
-		
-		-- basegame stuff 
+		--acceleratorPedal, brakePedal = WheelsUtil.getSmoothedAcceleratorAndBrakePedals(self, acceleratorPedal, brakePedal, dt)
+
+		-- basegame stuff
 		if next(self.spec_motorized.differentials) ~= nil and self.spec_motorized.motorizedNode ~= nil then
-		
 			local absAcceleratorPedal = math.abs(acceleratorPedal)
 			local minGearRatio, maxGearRatio = motor:getMinMaxGearRatio()
-			
+
 			local maxSpeed = nil
 			if maxGearRatio >= 0 then
 				maxSpeed = motor:getMaximumForwardSpeed()
 			else
 				maxSpeed = motor:getMaximumBackwardSpeed()
 			end
-			
+
 			maxSpeed = math.min(maxSpeed, motor:getSpeedLimit() / 3.6)
 			local maxAcceleration = motor:getAccelerationLimit()
 			local maxMotorRotAcceleration = motor:getMotorRotationAccelerationLimit()
@@ -719,9 +711,20 @@ function realismAddon_gearbox_overrides.updateWheelsPhysics(self, superFunc, dt,
 			neededPtoTorque = neededPtoTorque / motor:getPtoMotorRpmRatio()
 			local neutralActive = minGearRatio == 0 and maxGearRatio == 0 or manualClutchValue > 0.9
 			motor:setExternalTorqueVirtualMultiplicator(ptoTorqueVirtualMultiplicator)
-			
+
 			if not neutralActive then
-				self:controlVehicle(absAcceleratorPedal, maxSpeed, maxAcceleration, minMotorRpm * math.pi / 30, maxMotorRpm * math.pi / 30, maxMotorRotAcceleration, minGearRatio, maxGearRatio, motor:getMaxClutchTorque(), neededPtoTorque)
+				self:controlVehicle(
+					absAcceleratorPedal,
+					maxSpeed,
+					maxAcceleration,
+					minMotorRpm * math.pi / 30,
+					maxMotorRpm * math.pi / 30,
+					maxMotorRotAcceleration,
+					minGearRatio,
+					maxGearRatio,
+					motor:getMaxClutchTorque(),
+					neededPtoTorque
+				)
 			else
 				self:controlVehicle(0, 0, 0, 0, math.huge, 0, 0, 0, 0, 0)
 
@@ -729,69 +732,58 @@ function realismAddon_gearbox_overrides.updateWheelsPhysics(self, superFunc, dt,
 			end
 		end
 
-		self:brake(brakePedal)		
-		
-		
+		self:brake(brakePedal)
 	else
 		superFunc(self, dt, currentSpeed, acceleration, doHandbrake, stopAndGoBraking)
 	end
 end
-WheelsUtil.updateWheelsPhysics = Utils.overwrittenFunction(WheelsUtil.updateWheelsPhysics, realismAddon_gearbox_overrides.updateWheelsPhysics)
-
+WheelsUtil.updateWheelsPhysics =
+	Utils.overwrittenFunction(WheelsUtil.updateWheelsPhysics, realismAddon_gearbox_overrides.updateWheelsPhysics)
 
 -- allowing to edit XML Files while loading to fix basegame Transmissions
-local modDirectory = g_currentModDirectory 
+local modDirectory = g_currentModDirectory
 local modName = g_currentModName
 
-
 function realismAddon_gearbox_overrides.load(self, superFunc, vehicleData, a, b, c, d, e)
-	
 	-- call superFunc first actually because vehicleData is only complete afterwards
 	superFunc(self, vehicleData, a, b, c, d, e)
-	
-	-- set up the XML files 
+
+	-- set up the XML files
 	local vehicleXML = self.xmlFile
-	local xmlFile = loadXMLFile("xmlEdits", modDirectory.."xmlEdits.xml")
-	
+	local xmlFile = loadXMLFile("xmlEdits", modDirectory .. "xmlEdits.xml")
+
 	-- get modName (so this also works with Mods or DLC's)
 	local modName, baseDirectory = Utils.getModNameAndBaseDirectory(vehicleData.storeItem.xmlFilename)
 	local name = string.split(vehicleData.storeItem.xmlFilename, "FarmingSimulator2025/")
-	
+
 	local i = 0
 	while true do
-		
-		-- get the name from our XML and check if it matches 
-		local nameToEdit = getXMLString(xmlFile, "xmlEdits.editFile("..i..")#xmlFilename")
+		-- get the name from our XML and check if it matches
+		local nameToEdit = getXMLString(xmlFile, "xmlEdits.editFile(" .. i .. ")#xmlFilename")
 		if nameToEdit == nil or nameToEdit == "" then
 			break
 		end
-						
+
 		if nameToEdit == name[2] or nameToEdit == vehicleData.storeItem.xmlFilename then
-				
-			-- if it matches run through all XML paths and change the values 
+			-- if it matches run through all XML paths and change the values
 			local x = 0
 			while true do
-			
-				local path = getXMLString(xmlFile, "xmlEdits.editFile("..i..").attributes.attribute("..x..")#path")
-				local value = getXMLString(xmlFile, "xmlEdits.editFile("..i..").attributes.attribute("..x..")#value")
-				
+				local path =
+					getXMLString(xmlFile, "xmlEdits.editFile(" .. i .. ").attributes.attribute(" .. x .. ")#path")
+				local value =
+					getXMLString(xmlFile, "xmlEdits.editFile(" .. i .. ").attributes.attribute(" .. x .. ")#value")
+
 				if path == nil or path == "" then
 					break
 				end
-								
+
 				setXMLString(self.xmlFile.handle, path, value)
-				
+
 				x = x + 1
 			end
-		
 		end
-		
+
 		i = i + 1
 	end
-	
 end
 Vehicle.load = Utils.overwrittenFunction(Vehicle.load, realismAddon_gearbox_overrides.load)
-
-
-
-

--- a/realismAddon_gearbox_register.lua
+++ b/realismAddon_gearbox_register.lua
@@ -1,31 +1,32 @@
 -- by modelleicher ( Farming Agency )
--- register realismAddon_gearbox specializations and insert to vehicles 
-
+-- register realismAddon_gearbox specializations and insert to vehicles
 
 -- realismAddon_gearbox_spec contains everything that needs to be in a spec (e.g. everything that is not an overwritten function)
-g_specializationManager:addSpecialization("realismAddon_gearbox_spec", "realismAddon_gearbox_spec", g_currentModDirectory.."realismAddon_gearbox_spec.lua")
+g_specializationManager:addSpecialization(
+	"realismAddon_gearbox_spec",
+	"realismAddon_gearbox_spec",
+	g_currentModDirectory .. "realismAddon_gearbox_spec.lua"
+)
 -- realismAddon_gearbox_inputs contains only Inputs and Functions that are called via the Input Callback
-g_specializationManager:addSpecialization("realismAddon_gearbox_inputs", "realismAddon_gearbox_inputs", g_currentModDirectory.."realismAddon_gearbox_inputs.lua")
+g_specializationManager:addSpecialization(
+	"realismAddon_gearbox_inputs",
+	"realismAddon_gearbox_inputs",
+	g_currentModDirectory .. "realismAddon_gearbox_inputs.lua"
+)
 -- everything else is in realismAddon_gearbox_overrides
-
-
 
 realismAddon_gearbox_register = {}
 
 realismAddon_gearbox_register.done = false
 
 function realismAddon_gearbox_register:register(name)
-
 	if not realismAddon_gearbox_register.done then
-    
 		for _, vehicle in pairs(g_vehicleTypeManager:getTypes()) do
-			
 			local motorized = false
 			local realismAddon_gearbox_inputs = false
 			local realismAddon_gearbox_spec = false
-						
+
 			for _, spec in pairs(vehicle.specializationNames) do
-			
 				if spec == "motorized" then -- check for motorized, only insert into motorized
 					motorized = true
 				end
@@ -35,19 +36,23 @@ function realismAddon_gearbox_register:register(name)
 				if spec == "realismAddon_gearbox_spec" then -- don't insert if already inserted
 					realismAddon_gearbox_spec = true
 				end
-
-				
-			end    
+			end
 			if motorized then
 				if not realismAddon_gearbox_spec then
-					g_vehicleTypeManager:addSpecialization(vehicle.name, "FS25_realismAddon_gearbox.realismAddon_gearbox_spec")
-				end				
-				if not realismAddon_gearbox_inputs then				
-					g_vehicleTypeManager:addSpecialization(vehicle.name, "FS25_realismAddon_gearbox.realismAddon_gearbox_inputs")
+					g_vehicleTypeManager:addSpecialization(
+						vehicle.name,
+						"FS25_realismAddon_gearbox.realismAddon_gearbox_spec"
+					)
+				end
+				if not realismAddon_gearbox_inputs then
+					g_vehicleTypeManager:addSpecialization(
+						vehicle.name,
+						"FS25_realismAddon_gearbox.realismAddon_gearbox_inputs"
+					)
 				end
 			end
 		end
-		
+
 		realismAddon_gearbox_register.done = true
 	end
 end

--- a/realismAddon_gearbox_spec.lua
+++ b/realismAddon_gearbox_spec.lua
@@ -1,10 +1,9 @@
 -- by modelleicher ( Farming Agency )
 
-
 realismAddon_gearbox_spec = {}
 
 function realismAddon_gearbox_spec.prerequisitesPresent(specializations)
-    return true
+	return true
 end
 
 function realismAddon_gearbox_spec.registerEventListeners(vehicleType)
@@ -13,10 +12,26 @@ function realismAddon_gearbox_spec.registerEventListeners(vehicleType)
 end
 
 function realismAddon_gearbox_spec.registerFunctions(vehicleType)
-	SpecializationUtil.registerFunction(vehicleType, "processSecondGroupSetInputs", realismAddon_gearbox_spec.processSecondGroupSetInputs)
-	SpecializationUtil.registerFunction(vehicleType, "processHandbrakeInput", realismAddon_gearbox_spec.processHandbrakeInput)	
-	SpecializationUtil.registerFunction(vehicleType, "getMotorBlowOffValveStateRAGB", realismAddon_gearbox_spec.getMotorBlowOffValveStateRAGB)
-	SpecializationUtil.registerFunction(vehicleType, "getBoostPressureRAGB", realismAddon_gearbox_spec.getBoostPressureRAGB)
+	SpecializationUtil.registerFunction(
+		vehicleType,
+		"processSecondGroupSetInputs",
+		realismAddon_gearbox_spec.processSecondGroupSetInputs
+	)
+	SpecializationUtil.registerFunction(
+		vehicleType,
+		"processHandbrakeInput",
+		realismAddon_gearbox_spec.processHandbrakeInput
+	)
+	SpecializationUtil.registerFunction(
+		vehicleType,
+		"getMotorBlowOffValveStateRAGB",
+		realismAddon_gearbox_spec.getMotorBlowOffValveStateRAGB
+	)
+	SpecializationUtil.registerFunction(
+		vehicleType,
+		"getBoostPressureRAGB",
+		realismAddon_gearbox_spec.getBoostPressureRAGB
+	)
 end
 
 function realismAddon_gearbox_spec.getMotorBlowOffValveStateRAGB(self, superFunc)
@@ -25,7 +40,6 @@ end
 g_soundManager:registerModifierType("BLOW_OFF_VALVE_RAGB", realismAddon_gearbox_spec.getMotorBlowOffValveStateRAGB)
 
 function realismAddon_gearbox_spec.getBoostPressureRAGB(self)
-
 	return self.spec_motorized.motor.boostPressureME
 end
 
@@ -34,24 +48,24 @@ g_soundManager:registerModifierType("BOOST_PRESSURE_RAGB", realismAddon_gearbox_
 -- helper function to get XML value on key and fallback key (basically instead of getConfigurationValue but without Schemas)
 function getXMLValueFallback(xml, key, defaultKey, path, type, propertyCheck, defaultValue)
 	if propertyCheck then
-		if hasXMLProperty(xml, key..path) or hasXMLProperty(xml, defaultKey..path) then 
+		if hasXMLProperty(xml, key .. path) or hasXMLProperty(xml, defaultKey .. path) then
 			return true
 		else
 			return false
 		end
 	else
-		local value = getXMLString(xml, key..path) 
-        local value2 = getXMLString(xml, defaultKey..path)         
-        if type == "bool" then
-            value = getXMLBool(xml, key..path) 
-            value2 = getXMLBool(xml, defaultKey..path)            
-        elseif type == "float" then
-            value = getXMLFloat(xml, key..path) 
-            value2 = getXMLFloat(xml, defaultKey..path)             
-        end
+		local value = getXMLString(xml, key .. path)
+		local value2 = getXMLString(xml, defaultKey .. path)
+		if type == "bool" then
+			value = getXMLBool(xml, key .. path)
+			value2 = getXMLBool(xml, defaultKey .. path)
+		elseif type == "float" then
+			value = getXMLFloat(xml, key .. path)
+			value2 = getXMLFloat(xml, defaultKey .. path)
+		end
 
 		if value == nil then
-            value = value2
+			value = value2
 			if value == nil then
 				return defaultValue
 			end
@@ -61,67 +75,95 @@ function getXMLValueFallback(xml, key, defaultKey, path, type, propertyCheck, de
 end
 
 function realismAddon_gearbox_spec:onLoad(savegame)
+	self.spec_realismAddon_gearbox = {}
+	local spec = self.spec_realismAddon_gearbox
 
-    self.spec_realismAddon_gearbox = {}
-    local spec = self.spec_realismAddon_gearbox
-
-	-- get config key and default key 
-	local key, _ = ConfigurationUtil.getXMLConfigurationKey(self.xmlFile,  self.configurations.motor, "vehicle.motorized.motorConfigurations.motorConfiguration", "vehicle.motorized", "motor")
+	-- get config key and default key
+	local key, _ = ConfigurationUtil.getXMLConfigurationKey(
+		self.xmlFile,
+		self.configurations.motor,
+		"vehicle.motorized.motorConfigurations.motorConfiguration",
+		"vehicle.motorized",
+		"motor"
+	)
 	local defaultKey = "vehicle.motorized.motorConfigurations.motorConfiguration(0)"
 
-    -- groups second set key 
-    local groupsSecondSetKey = ".transmission.realismAddon_gearbox.groupsSecondSet"
+	-- groups second set key
+	local groupsSecondSetKey = ".transmission.realismAddon_gearbox.groupsSecondSet"
 
-    -- since we don't use the predefined xml Schemas we need to use the handle of the XML file
-    local xml = self.xmlFile.handle    
+	-- since we don't use the predefined xml Schemas we need to use the handle of the XML file
+	local xml = self.xmlFile.handle
 
-	-- check for and load groups second set 
+	-- check for and load groups second set
 	local hasGroupsSecondSet = getXMLValueFallback(xml, key, defaultKey, groupsSecondSetKey, nil, true)
 	if hasGroupsSecondSet then
-			
 		spec.groupsSecondSet = {}
 		spec.groupsSecondSet.groups = {}
 		spec.groupsSecondSet.currentGroup = 1
 		spec.groupsSecondSet.wantedGroup = nil
-        spec.groupsSecondSet.lastGroupSecond = nil
-        spec.groupsSecondSet.lastGroupFirst = nil
+		spec.groupsSecondSet.lastGroupSecond = nil
+		spec.groupsSecondSet.lastGroupFirst = nil
 
-        -- powershift allows for shifting without clutch - preselect means that the range is preselected and then automatically shifts once the clutch is pressed 
-		spec.groupsSecondSet.powerShift = getXMLValueFallback(xml, key, defaultKey, groupsSecondSetKey.."#powerShift", "bool", nil, false)
-		spec.groupsSecondSet.preselect = getXMLValueFallback(xml, key, defaultKey, groupsSecondSetKey.."#preselect", "bool", nil, false)
+		-- powershift allows for shifting without clutch - preselect means that the range is preselected and then automatically shifts once the clutch is pressed
+		spec.groupsSecondSet.powerShift =
+			getXMLValueFallback(xml, key, defaultKey, groupsSecondSetKey .. "#powerShift", "bool", nil, false)
+		spec.groupsSecondSet.preselect =
+			getXMLValueFallback(xml, key, defaultKey, groupsSecondSetKey .. "#preselect", "bool", nil, false)
 
-        -- load all individual group ratios
+		-- load all individual group ratios
 		local i = 0
 		while true do
-			local ratio = getXMLValueFallback(xml, key, defaultKey, groupsSecondSetKey..".group("..tostring(i)..")#ratio", "float")
-			local name = getXMLValueFallback(xml, key, defaultKey, groupsSecondSetKey..".group("..tostring(i)..")#name", nil, nil, i+1)
-			local isDefault = getXMLValueFallback(xml, key, defaultKey, groupsSecondSetKey..".group("..tostring(i)..")#isDefault", "bool", nil, false)
-						
-			if ratio ~= nil then
-                if isDefault then
-                    spec.groupsSecondSet.currentGroup = i+1
-                end              
+			local ratio = getXMLValueFallback(
+				xml,
+				key,
+				defaultKey,
+				groupsSecondSetKey .. ".group(" .. tostring(i) .. ")#ratio",
+				"float"
+			)
+			local name = getXMLValueFallback(
+				xml,
+				key,
+				defaultKey,
+				groupsSecondSetKey .. ".group(" .. tostring(i) .. ")#name",
+				nil,
+				nil,
+				i + 1
+			)
+			local isDefault = getXMLValueFallback(
+				xml,
+				key,
+				defaultKey,
+				groupsSecondSetKey .. ".group(" .. tostring(i) .. ")#isDefault",
+				"bool",
+				nil,
+				false
+			)
 
-				spec.groupsSecondSet.groups[i+1] = {ratio = ratio, name = name, isDefault = isDefault}
+			if ratio ~= nil then
+				if isDefault then
+					spec.groupsSecondSet.currentGroup = i + 1
+				end
+
+				spec.groupsSecondSet.groups[i + 1] = { ratio = ratio, name = name, isDefault = isDefault }
 			else
 				break
 			end
-		
-			i = i+1
-		end 
 
-        -- backup gearGroup names since we add the 2 names of the default and second group set together later 
-        spec.groupsSecondSet.gearGroupNamesBackup = {}
-    	local motor = self.spec_motorized.motor    
-        for x = 1, #motor.gearGroups do
-            spec.groupsSecondSet.gearGroupNamesBackup[x] = motor.gearGroups[x].name
-        end
+			i = i + 1
+		end
 
-        -- in case we don't have any group ratios set everything to nil 
-        if #spec.groupsSecondSet.groups == 0 then
-            spec.groupsSecondSet = nil
-        end
-		
+		-- backup gearGroup names since we add the 2 names of the default and second group set together later
+		spec.groupsSecondSet.gearGroupNamesBackup = {}
+		local motor = self.spec_motorized.motor
+		for x = 1, #motor.gearGroups do
+			spec.groupsSecondSet.gearGroupNamesBackup[x] = motor.gearGroups[x].name
+		end
+
+		-- in case we don't have any group ratios set everything to nil
+		if #spec.groupsSecondSet.groups == 0 then
+			spec.groupsSecondSet = nil
+		end
+
 		-- parse secondGroup property from gearLevers > gearLever(n) > state (credits AckermannM)
 		spec.secondGroupLevers = {}
 		local leversKey = "vehicle.motorized.gearLevers"
@@ -172,36 +214,33 @@ function realismAddon_gearbox_spec:onLoad(savegame)
 
 				j = j + 1
 			end
-		end		
-		
-	end   
-	
+		end
+	end
+
 	-- handbrake
 	spec.handbrakeStateME = false
 	spec.handbrakeUseME = true
-	
-	-- additional clutch value for auto clutch, 0 is closed for Giants Clutch 
+
+	-- additional clutch value for auto clutch, 0 is closed for Giants Clutch
 	spec.clutchValueOverride = 0
-	
 end
 
 -- process the inputs of the secondGroupSet Input Call
 function realismAddon_gearbox_spec:processSecondGroupSetInputs(wantedGroup, noEventSend)
 	setGroupSecondEvent.sendEvent(self, wantedGroup, noEventSend)
-	
+
 	local motor = self.spec_motorized.motor
 	local spec = self.spec_realismAddon_gearbox
 
-    -- if the groupSet is powerShift or if the clutch is fully depressed allow shifting right away
-	if spec.groupsSecondSet.powerShift or motor.manualClutchValue > 0.8 then 
-        spec.groupsSecondSet.currentGroup = wantedGroup  
-    elseif spec.groupsSecondSet.preselect then -- if the groupSet is preselect type then don't shift right away but put wanted group into wantedGroup variable
+	-- if the groupSet is powerShift or if the clutch is fully depressed allow shifting right away
+	if spec.groupsSecondSet.powerShift or motor.manualClutchValue > 0.8 then
+		spec.groupsSecondSet.currentGroup = wantedGroup
+	elseif spec.groupsSecondSet.preselect then -- if the groupSet is preselect type then don't shift right away but put wanted group into wantedGroup variable
 		spec.groupsSecondSet.wantedGroup = wantedGroup
 	end
-
 end
 
--- process inputs of handbrake 
+-- process inputs of handbrake
 function realismAddon_gearbox_spec:processHandbrakeInput(state, noEventSend)
 	setHandbrakeEvent.sendEvent(self, state, noEventSend)
 
@@ -209,18 +248,14 @@ function realismAddon_gearbox_spec:processHandbrakeInput(state, noEventSend)
 	spec.handbrakeStateME = state
 end
 
-
 -- UPDATE
 function realismAddon_gearbox_spec:onUpdate(dt)
-
 	if self:getIsActive() then
-	
-		local spec = self.spec_realismAddon_gearbox	
-        local motor = self.spec_motorized.motor       
-	
-		-- check if transmission is manual 
+		local spec = self.spec_realismAddon_gearbox
+		local motor = self.spec_motorized.motor
+
+		-- check if transmission is manual
 		if realismAddon_gearbox_overrides.checkIsManual(motor) then
-		
 			if self:getIsMotorStarted() then
 				if self.isClient and self.spec_motorized.samples.blowOffValve ~= nil then
 					if motor.blowOffValveStateME ~= nil and motor.blowOffValveStateME > 0 then
@@ -229,37 +264,43 @@ function realismAddon_gearbox_spec:onUpdate(dt)
 						end
 					elseif g_soundManager:getIsSamplePlaying(self.spec_motorized.samples.blowOffValve) then
 						g_soundManager:stopSample(self.spec_motorized.samples.blowOffValve)
-					end		
+					end
 				end
 			end
-	
-			if spec.groupsSecondSet ~= nil then	
-                
-                -- reset the name as soon as currentGroup changes
+
+			if spec.groupsSecondSet ~= nil then
+				-- reset the name as soon as currentGroup changes
 				if motor.gearGroups ~= nil and motor.activeGearGroupIndex > 0 and #motor.gearGroups > 0 then
-					if spec.groupsSecondSet.lastGroupSecond ~= spec.groupsSecondSet.currentGroup or spec.groupsSecondSet.lastGroupFirst ~= motor.activeGearGroupIndex then
-						local name = tostring(spec.groupsSecondSet.gearGroupNamesBackup[motor.activeGearGroupIndex]).." "..tostring(spec.groupsSecondSet.groups[spec.groupsSecondSet.currentGroup].name)
+					if
+						spec.groupsSecondSet.lastGroupSecond ~= spec.groupsSecondSet.currentGroup
+						or spec.groupsSecondSet.lastGroupFirst ~= motor.activeGearGroupIndex
+					then
+						local name = tostring(spec.groupsSecondSet.gearGroupNamesBackup[motor.activeGearGroupIndex])
+							.. " "
+							.. tostring(spec.groupsSecondSet.groups[spec.groupsSecondSet.currentGroup].name)
 						local gearGroup = motor.gearGroups[motor.activeGearGroupIndex]
 						if gearGroup ~= nil then
-							gearGroup.name = name  
+							gearGroup.name = name
 						end
-						spec.groupsSecondSet.lastGroupSecond = spec.groupsSecondSet.currentGroup 
+						spec.groupsSecondSet.lastGroupSecond = spec.groupsSecondSet.currentGroup
 						spec.groupsSecondSet.lastGroupFirst = motor.activeGearGroupIndex
 					end
 				end
-				
-                -- if we have a wantedGroup set differently to currentGroup and we are in preselect mode we check for clutch opening and set the group if the clutch is open
-                -- this needs no further synchronization because the clutch and wantedGroup are already synchronized
-				if spec.groupsSecondSet.wantedGroup ~= nil and spec.groupsSecondSet.wantedGroup ~= spec.groupsSecondSet.currentGroup and spec.groupsSecondSet.preselect then               
-                    if motor.manualClutchValue > 0.8 then
+
+				-- if we have a wantedGroup set differently to currentGroup and we are in preselect mode we check for clutch opening and set the group if the clutch is open
+				-- this needs no further synchronization because the clutch and wantedGroup are already synchronized
+				if
+					spec.groupsSecondSet.wantedGroup ~= nil
+					and spec.groupsSecondSet.wantedGroup ~= spec.groupsSecondSet.currentGroup
+					and spec.groupsSecondSet.preselect
+				then
+					if motor.manualClutchValue > 0.8 then
 						spec.groupsSecondSet.currentGroup = spec.groupsSecondSet.wantedGroup
-                        spec.groupsSecondSet.wantedGroup = nil                                  
-					end	
+						spec.groupsSecondSet.wantedGroup = nil
+					end
 				end
-			
 			end
-			
-			
+
 			-- animate secondGroup levers (credits AckermannM)
 			if spec.secondGroupLevers ~= nil and spec.groupsSecondSet.currentGroup ~= nil then
 				local secondGroupIndex = spec.groupsSecondSet.currentGroup
@@ -291,12 +332,10 @@ function realismAddon_gearbox_spec:onUpdate(dt)
 						end
 					end
 				end
-			end							
-		end	
-	end	
+			end
+		end
+	end
 end
-
-
 
 setGroupSecondEvent = {}
 local setGroupSecondEvent_mt = Class(setGroupSecondEvent, Event)
@@ -340,14 +379,12 @@ end
 function setGroupSecondEvent.sendEvent(object, wantedState, noEventSend)
 	if noEventSend == nil or noEventSend == false then
 		if g_server ~= nil then
-			g_server:broadcastEvent(setGroupSecondEvent.new(object, wantedState), nil, nil, object)			
+			g_server:broadcastEvent(setGroupSecondEvent.new(object, wantedState), nil, nil, object)
 		else
 			g_client:getServerConnection():sendEvent(setGroupSecondEvent.new(object, wantedState))
 		end
 	end
 end
-
-
 
 setHandbrakeEvent = {}
 local setHandbrakeEvent_mt = Class(setHandbrakeEvent, Event)
@@ -391,7 +428,7 @@ end
 function setHandbrakeEvent.sendEvent(object, wantedState, noEventSend)
 	if noEventSend == nil or noEventSend == false then
 		if g_server ~= nil then
-			g_server:broadcastEvent(setHandbrakeEvent.new(object, wantedState), nil, nil, object)			
+			g_server:broadcastEvent(setHandbrakeEvent.new(object, wantedState), nil, nil, object)
 		else
 			g_client:getServerConnection():sendEvent(setHandbrakeEvent.new(object, wantedState))
 		end

--- a/xmlEdits.xml
+++ b/xmlEdits.xml
@@ -1,220 +1,433 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 
 
 <xmlEdits>
 
-	<test value="Hello" />
+    <test value="Hello" />
 
-	<editFile xmlFilename="data/vehicles/johnDeere/series3650/series3650.xml">
+    <editFile xmlFilename="data/vehicles/johnDeere/series3650/series3650.xml">
         <attributes>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.groups#type" value="DEFAULT"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.groups#changeTime" value="0.5"/>
-			
-			
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#maxSpeed" value="nil"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#maxSpeed" value="nil"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#maxSpeed" value="nil"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#maxSpeed" value="nil"/>
-			
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#name" value="1"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#name" value="2"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#name" value="3"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#name" value="4"/>
-			
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#actionName" value="SHIFT_GEAR_SELECT_1"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#actionName" value="SHIFT_GEAR_SELECT_2"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#actionName" value="SHIFT_GEAR_SELECT_3"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#actionName" value="SHIFT_GEAR_SELECT_4"/>					
-			
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#reverseName" value="-1"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#reverseName" value="-2"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#reverseName" value="-3"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#reverseName" value="-4"/>				
-			
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet#powerShift" value="true"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#ratio" value="0.8162"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#name" value="L"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#ratio" value="1.0"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#name" value="H"/>	
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#isDefault" value="true"/>	
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.groups#type"
+                value="DEFAULT" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.groups#changeTime"
+                value="0.5" />
 
-            <attribute path="vehicle.motorized.gearLevers.gearLever(1).state(2)#xRot" value="-10"/>	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(1).state(3)#xRot" value="10"/>	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(1).state(3)#zRot" value="4.5"/>	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(1).state(4)#zRot" value="4.5"/>	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(1).state(4)#xRot" value="-10"/>	
-				
-            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(0)#xRot" value="6"/>	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(1)#xRot" value="6"/>	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(2)#xRot" value="6"/>	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(3)#xRot" value="6"/>	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(4)#xRot" value="6"/>	
 
-            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(9)#group" value="0" />	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(10)#group" value="0"/>	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(9)#secondGroup" value="1" />	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(10)#secondGroup" value="2"/>	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(9)#xRot" value="-4" />	
-            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(10)#xRot" value="6"/>	
-         </attributes>
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#maxSpeed"
+                value="nil" />
+
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#name"
+                value="1" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#name"
+                value="2" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#name"
+                value="3" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#name"
+                value="4" />
+
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#actionName"
+                value="SHIFT_GEAR_SELECT_1" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#actionName"
+                value="SHIFT_GEAR_SELECT_2" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#actionName"
+                value="SHIFT_GEAR_SELECT_3" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#actionName"
+                value="SHIFT_GEAR_SELECT_4" />
+
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#reverseName"
+                value="-1" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#reverseName"
+                value="-2" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#reverseName"
+                value="-3" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#reverseName"
+                value="-4" />
+
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet#powerShift"
+                value="true" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#ratio"
+                value="0.8162" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#name"
+                value="L" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#ratio"
+                value="1.0" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#name"
+                value="H" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#isDefault"
+                value="true" />
+
+            <attribute path="vehicle.motorized.gearLevers.gearLever(1).state(2)#xRot" value="-10" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(1).state(3)#xRot" value="10" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(1).state(3)#zRot" value="4.5" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(1).state(4)#zRot" value="4.5" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(1).state(4)#xRot" value="-10" />
+
+            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(0)#xRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(1)#xRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(2)#xRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(3)#xRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(4)#xRot" value="6" />
+
+            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(9)#group" value="0" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(10)#group" value="0" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(9)#secondGroup"
+                value="1" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(10)#secondGroup"
+                value="2" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(9)#xRot" value="-4" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(2).state(10)#xRot" value="6" />
+        </attributes>
     </editFile>
 
 
-	<editFile xmlFilename="data/vehicles/zetor/proximaHS120/proximaHS120.xml">
+    <editFile xmlFilename="data/vehicles/zetor/proximaHS120/proximaHS120.xml">
         <attributes>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet#powerShift" value="false"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#ratio" value="0.3579"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#name" value="L"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#ratio" value="1.0"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#name" value="H"/>	
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#isDefault" value="true"/>
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet#powerShift"
+                value="false" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#ratio"
+                value="0.3579" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#name"
+                value="L" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#ratio"
+                value="1.0" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#name"
+                value="H" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#isDefault"
+                value="true" />
 
 
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#maxSpeed" value="nil"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#maxSpeed" value="nil"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#maxSpeed" value="nil"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#maxSpeed" value="nil"/>
-			
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#name" value="1"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#name" value="2"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#name" value="3"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#name" value="4"/>	
-			
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#actionName" value="SHIFT_GEAR_SELECT_1"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#actionName" value="SHIFT_GEAR_SELECT_2"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#actionName" value="SHIFT_GEAR_SELECT_3"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#actionName" value="SHIFT_GEAR_SELECT_4"/>					
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#maxSpeed"
+                value="nil" />
 
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#reverseName" value="1R"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#reverseName" value="2R"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#reverseName" value="3R"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#reverseName" value="4R"/>								
-			
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#xRot" value="-4"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#zRot" value="0"/>				
-	
-         </attributes>
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#name"
+                value="1" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#name"
+                value="2" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#name"
+                value="3" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#name"
+                value="4" />
+
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#actionName"
+                value="SHIFT_GEAR_SELECT_1" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#actionName"
+                value="SHIFT_GEAR_SELECT_2" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#actionName"
+                value="SHIFT_GEAR_SELECT_3" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#actionName"
+                value="SHIFT_GEAR_SELECT_4" />
+
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#reverseName"
+                value="1R" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#reverseName"
+                value="2R" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#reverseName"
+                value="3R" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#reverseName"
+                value="4R" />
+
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#xRot" value="-4" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#zRot" value="0" />
+
+        </attributes>
     </editFile>
 
 
-	<editFile xmlFilename="data/vehicles/zetor/forterraHSX140/forterraHSX140.xml">
+    <editFile xmlFilename="data/vehicles/zetor/forterraHSX140/forterraHSX140.xml">
         <attributes>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet#powerShift" value="false"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#ratio" value="0.3591"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#name" value="L"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#ratio" value="1.0"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#name" value="H"/>	
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#isDefault" value="true"/>
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet#powerShift"
+                value="false" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#ratio"
+                value="0.3591" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#name"
+                value="L" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#ratio"
+                value="1.0" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#name"
+                value="H" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#isDefault"
+                value="true" />
 
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#maxSpeed" value="nil"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#maxSpeed" value="nil"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#maxSpeed" value="nil"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(8)#maxSpeed" value="nil"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(9)#maxSpeed" value="nil"/>
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(8)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(9)#maxSpeed"
+                value="nil" />
 
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#name" value="1"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#name" value="2"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#name" value="3"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#name" value="4"/>				
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#name" value="5"/>
-			
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#reverseName" value="1R"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#reverseName" value="2R"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#reverseName" value="3R"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#reverseName" value="4R"/>				
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#reverseName" value="5R"/>				
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#name"
+                value="1" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#name"
+                value="2" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#name"
+                value="3" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#name"
+                value="4" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#name"
+                value="5" />
 
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#maxSpeed" value="11.00"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#maxSpeed" value="16.00"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#maxSpeed" value="25.00"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#maxSpeed" value="38.00"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#maxSpeed" value="49.00"/>	
-			
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#actionName" value="SHIFT_GEAR_SELECT_1"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#actionName" value="SHIFT_GEAR_SELECT_2"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#actionName" value="SHIFT_GEAR_SELECT_3"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#actionName" value="SHIFT_GEAR_SELECT_4"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#actionName" value="SHIFT_GEAR_SELECT_5"/>				
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#reverseName"
+                value="1R" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#reverseName"
+                value="2R" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#reverseName"
+                value="3R" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#reverseName"
+                value="4R" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#reverseName"
+                value="5R" />
 
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#xRot" value="6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#zRot" value="-6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#gear" value="1"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#xRot" value="-6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#zRot" value="0"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#gear" value="2"/>	
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#xRot" value="6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#zRot" value="0"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#gear" value="3"/>	
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#xRot" value="-6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#zRot" value="6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#gear" value="4"/>	
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#xRot" value="6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#zRot" value="6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#gear" value="5"/>				
-         </attributes>
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#maxSpeed"
+                value="11.00" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#maxSpeed"
+                value="16.00" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#maxSpeed"
+                value="25.00" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#maxSpeed"
+                value="38.00" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#maxSpeed"
+                value="49.00" />
+
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#actionName"
+                value="SHIFT_GEAR_SELECT_1" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#actionName"
+                value="SHIFT_GEAR_SELECT_2" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#actionName"
+                value="SHIFT_GEAR_SELECT_3" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#actionName"
+                value="SHIFT_GEAR_SELECT_4" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#actionName"
+                value="SHIFT_GEAR_SELECT_5" />
+
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#xRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#zRot" value="-6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#gear" value="1" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#xRot" value="-6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#zRot" value="0" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#gear" value="2" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#xRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#zRot" value="0" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#gear" value="3" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#xRot" value="-6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#zRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#gear" value="4" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#xRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#zRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#gear" value="5" />
+        </attributes>
     </editFile>
 
-	
-	
-	<editFile xmlFilename="data/vehicles/zetor/crystal/crystal.xml">
+
+    <editFile xmlFilename="data/vehicles/zetor/crystal/crystal.xml">
         <attributes>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet#powerShift" value="false"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#ratio" value="0.3591"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#name" value="L"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#ratio" value="1.0"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#name" value="H"/>	
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#isDefault" value="true"/>
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet#powerShift"
+                value="false" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#ratio"
+                value="0.3591" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(0)#name"
+                value="L" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#ratio"
+                value="1.0" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#name"
+                value="H" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.realismAddon_gearbox.groupsSecondSet.group(1)#isDefault"
+                value="true" />
 
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#maxSpeed" value="nil"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#maxSpeed" value="nil"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#maxSpeed" value="nil"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(8)#maxSpeed" value="nil"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(9)#maxSpeed" value="nil"/>
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(5)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(6)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(7)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(8)#maxSpeed"
+                value="nil" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(9)#maxSpeed"
+                value="nil" />
 
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#name" value="1"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#name" value="2"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#name" value="3"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#name" value="4"/>				
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#name" value="5"/>
-			
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#reverseName" value="1R"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#reverseName" value="2R"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#reverseName" value="3R"/>
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#reverseName" value="4R"/>				
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#reverseName" value="5R"/>				
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#name"
+                value="1" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#name"
+                value="2" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#name"
+                value="3" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#name"
+                value="4" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#name"
+                value="5" />
 
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#maxSpeed" value="11.00"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#maxSpeed" value="16.00"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#maxSpeed" value="27.00"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#maxSpeed" value="38.00"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#maxSpeed" value="49.00"/>	
-			
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#actionName" value="SHIFT_GEAR_SELECT_1"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#actionName" value="SHIFT_GEAR_SELECT_2"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#actionName" value="SHIFT_GEAR_SELECT_3"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#actionName" value="SHIFT_GEAR_SELECT_4"/>		
-            <attribute path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#actionName" value="SHIFT_GEAR_SELECT_5"/>				
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#reverseName"
+                value="1R" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#reverseName"
+                value="2R" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#reverseName"
+                value="3R" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#reverseName"
+                value="4R" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#reverseName"
+                value="5R" />
 
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#xRot" value="6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#zRot" value="-6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#gear" value="1"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#xRot" value="-6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#zRot" value="0"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#gear" value="2"/>	
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#xRot" value="6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#zRot" value="0"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#gear" value="3"/>	
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#xRot" value="-6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#zRot" value="6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#gear" value="4"/>	
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#xRot" value="6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#zRot" value="6"/>				
-			<attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#gear" value="5"/>				
-         </attributes>
-    </editFile>	
-	
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#maxSpeed"
+                value="11.00" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#maxSpeed"
+                value="16.00" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#maxSpeed"
+                value="27.00" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#maxSpeed"
+                value="38.00" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#maxSpeed"
+                value="49.00" />
+
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(0)#actionName"
+                value="SHIFT_GEAR_SELECT_1" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(1)#actionName"
+                value="SHIFT_GEAR_SELECT_2" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(2)#actionName"
+                value="SHIFT_GEAR_SELECT_3" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(3)#actionName"
+                value="SHIFT_GEAR_SELECT_4" />
+            <attribute
+                path="vehicle.motorized.motorConfigurations.motorConfiguration(0).transmission.forwardGear(4)#actionName"
+                value="SHIFT_GEAR_SELECT_5" />
+
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#xRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#zRot" value="-6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(1)#gear" value="1" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#xRot" value="-6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#zRot" value="0" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(2)#gear" value="2" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#xRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#zRot" value="0" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(3)#gear" value="3" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#xRot" value="-6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#zRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(4)#gear" value="4" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#xRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#zRot" value="6" />
+            <attribute path="vehicle.motorized.gearLevers.gearLever(0).state(5)#gear" value="5" />
+        </attributes>
+    </editFile>
+
 </xmlEdits>
-
-
-
-


### PR DESCRIPTION
This pull request proposes version 0.9.0.6 of the RealismAddon: Gearbox mod, focusing on improved support for range splitter switches, enhanced multiplayer synchronization. The update adds a new input binding for range splitter-style gear shifting, fixes a multiplayer bug related to hand throttle synchronization, and applies StyLua across all files.

**New Features and Input Improvements**
- Added a new input binding (`RAGB_GROUPSECOND_TWO_OR_ONE`) to support range splitter switches (e.g., SKRS shift knobs), allowing button press to switch to H and release to L in the second group set. This includes corresponding changes in `modDesc.xml` and `realismAddon_gearbox_inputs.lua`. [[1]](diffhunk://#diff-df684b6494cdaf5bb8da437bdee1f29c2c34c9d1114e641d1159f2ae323bcb27L31-R82) [[2]](diffhunk://#diff-df684b6494cdaf5bb8da437bdee1f29c2c34c9d1114e641d1159f2ae323bcb27R107-R109) [[3]](diffhunk://#diff-df684b6494cdaf5bb8da437bdee1f29c2c34c9d1114e641d1159f2ae323bcb27R138) [[4]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51R28) [[5]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51L113-L139)
- Refactored the input event registration and handling code for clarity and maintainability, including expanded formatting and removal of unnecessary blank lines. [[1]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51L52-R81) [[2]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51L148-L151) [[3]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51L163-R183)

**Multiplayer Synchronization Enhancements**
- Fixed an issue where the hand throttle would be set to around 50% when entering vehicles or coupling/decoupling attachments in multiplayer. Added forced synchronization after load and on attach/detach events. [[1]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51R197-L186) [[2]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51R227-L221) [[3]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51L271-R329)

**Code Quality and Miscellaneous**
- Improved code formatting and consistency across Lua files, including better function overwriting and removal of redundant blank lines. [[1]](diffhunk://#diff-4c439d9d9a2a218d5318e29c172e24e988563b38fb179fc45d93979ec7f483ceL3) [[2]](diffhunk://#diff-4c439d9d9a2a218d5318e29c172e24e988563b38fb179fc45d93979ec7f483ceL14-R16) [[3]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51L13-L19) [[4]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51L74-L81) [[5]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51L97-L98) [[6]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51L230) [[7]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51L240-L249) [[8]](diffhunk://#diff-1f4c5c01f3dbf983c8d88b5e78daca0a7574760b1281ddc4c9f49cc487126b51L259)

These changes collectively improve the usability of the gearbox mod, especially for users with advanced shifter hardware and those playing in multiplayer environments.